### PR TITLE
Add guarded_transmute_vec_* functions

### DIFF
--- a/tests/guarded_transmute_vec/mod.rs
+++ b/tests/guarded_transmute_vec/mod.rs
@@ -1,0 +1,40 @@
+use safe_transmute::{ErrorReason, Error, guarded_transmute_vec};
+
+
+#[test]
+fn too_short() {
+    unsafe {
+        assert_eq!(guarded_transmute_vec::<u16>(vec![]),
+                   Err(Error {
+                       required: 16 / 8,
+                       actual: 0,
+                       reason: ErrorReason::NotEnoughBytes,
+                   }));
+        assert_eq!(guarded_transmute_vec::<u16>(vec![0x00]),
+                   Err(Error {
+                       required: 16 / 8,
+                       actual: 1,
+                       reason: ErrorReason::NotEnoughBytes,
+                   }));
+    }
+}
+
+#[test]
+fn just_enough() {
+    unsafe {
+        assert_eq!(guarded_transmute_vec::<u16>(vec![0x00, 0x01]), Ok(vec![0x0100u16]));
+        assert_eq!(guarded_transmute_vec::<u16>(vec![0x00, 0x01, 0x00, 0x02]),
+                   Ok(vec![0x0100u16, 0x0200u16]));
+    }
+}
+
+#[test]
+fn too_much() {
+    unsafe {
+        assert_eq!(guarded_transmute_vec::<u16>(vec![0x00, 0x01, 0x00]), Ok(vec![0x0100u16]));
+        assert_eq!(guarded_transmute_vec::<u16>(vec![0x00, 0x01, 0x00, 0x02, 0x00]),
+                   Ok(vec![0x0100u16, 0x0200u16]));
+        assert_eq!(guarded_transmute_vec::<u16>(vec![0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00]),
+                   Ok(vec![0x0100u16, 0x0200u16, 0x0300u16]));
+    }
+}

--- a/tests/guarded_transmute_vec_pedantic/mod.rs
+++ b/tests/guarded_transmute_vec_pedantic/mod.rs
@@ -1,0 +1,47 @@
+use safe_transmute::{ErrorReason, Error, guarded_transmute_vec_pedantic};
+
+
+#[test]
+fn too_short() {
+    unsafe {
+        assert_eq!(guarded_transmute_vec_pedantic::<u16>(vec![]),
+                   Err(Error {
+                       required: 16 / 8,
+                       actual: 0,
+                       reason: ErrorReason::NotEnoughBytes,
+                   }));
+        assert_eq!(guarded_transmute_vec_pedantic::<u16>(vec![0x00]),
+                   Err(Error {
+                       required: 16 / 8,
+                       actual: 1,
+                       reason: ErrorReason::NotEnoughBytes,
+                   }));
+    }
+}
+
+#[test]
+fn just_enough() {
+    unsafe {
+        assert_eq!(guarded_transmute_vec_pedantic::<u16>(vec![0x00, 0x01]), Ok(vec![0x0100u16]));
+        assert_eq!(guarded_transmute_vec_pedantic::<u16>(vec![0x00, 0x01, 0x00, 0x02]),
+                   Ok(vec![0x0100u16, 0x0200u16]));
+    }
+}
+
+#[test]
+fn too_much() {
+    unsafe {
+        assert_eq!(guarded_transmute_vec_pedantic::<u16>(vec![0x00, 0x01, 0x00]),
+                   Err(Error {
+                       required: 16 / 8,
+                       actual: 3,
+                       reason: ErrorReason::InexactByteCount,
+                   }));
+        assert_eq!(guarded_transmute_vec_pedantic::<u16>(vec![0x00, 0x01, 0x00, 0x02, 0x00]),
+                   Err(Error {
+                       required: 16 / 8,
+                       actual: 5,
+                       reason: ErrorReason::InexactByteCount,
+                   }));
+    }
+}

--- a/tests/guarded_transmute_vec_permissive/mod.rs
+++ b/tests/guarded_transmute_vec_permissive/mod.rs
@@ -1,0 +1,29 @@
+use safe_transmute::guarded_transmute_vec_permissive;
+
+
+#[test]
+fn too_short() {
+    unsafe {
+        assert_eq!(guarded_transmute_vec_permissive::<u16>(vec![]), vec![]);
+        assert_eq!(guarded_transmute_vec_permissive::<u16>(vec![0x00]), vec![]);
+    }
+}
+
+#[test]
+fn just_enough() {
+    unsafe {
+        assert_eq!(guarded_transmute_vec_permissive::<u16>(vec![0x00, 0x01]), vec![0x0100u16]);
+        assert_eq!(guarded_transmute_vec_permissive::<u16>(vec![0x00, 0x01, 0x00, 0x02]), vec![0x0100u16, 0x0200u16]);
+    }
+}
+
+#[test]
+fn too_much() {
+    unsafe {
+        assert_eq!(guarded_transmute_vec_permissive::<u16>(vec![0x00, 0x01, 0x00]), vec![0x0100u16]);
+        assert_eq!(guarded_transmute_vec_permissive::<u16>(vec![0x00, 0x01, 0x00, 0x02, 0x00]),
+                   vec![0x0100u16, 0x0200u16]);
+        assert_eq!(guarded_transmute_vec_permissive::<u16>(vec![0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00]),
+                   vec![0x0100u16, 0x0200u16, 0x0300u16]);
+    }
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,3 +5,6 @@ mod guarded_transmute_many;
 mod guarded_transmute_pedantic;
 mod guarded_transmute_many_pedantic;
 mod guarded_transmute_many_permissive;
+mod guarded_transmute_vec;
+mod guarded_transmute_vec_pedantic;
+mod guarded_transmute_vec_permissive;


### PR DESCRIPTION
These functions convert a `Vec<u8>` into a `Vec<T>`, while keeping the same size guards as the other functions, as well as attempting to reuse the allocated buffer. When properly used, they can save some copies.