### PR TITLE
Introducing the Guard API 💂

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use std::error::Error as StdError;
 use std::fmt;
 
+/// Describes possible errors originating from operations in this crate.
 pub type Error = GuardError;
 
 /// A transmutation error.
@@ -42,6 +43,7 @@ pub enum ErrorReason {
     /// The byte count is fine, but the data contains an invalid value for the target type.
     InvalidValue,
 }
+
 
 impl StdError for GuardError {
     fn description(&self) -> &str {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use std::error::Error as StdError;
 use std::fmt;
 
+pub type Error = GuardError;
 
 /// A transmutation error.
 ///
@@ -18,7 +19,7 @@ use std::fmt;
 /// # }
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct Error {
+pub struct GuardError {
     /// The required amount of bytes for transmutation.
     pub required: usize,
     /// The actual amount of bytes.
@@ -42,8 +43,7 @@ pub enum ErrorReason {
     InvalidValue,
 }
 
-
-impl StdError for Error {
+impl StdError for GuardError {
     fn description(&self) -> &str {
         match self.reason {
             ErrorReason::NotEnoughBytes => "Not enough bytes to fill type",
@@ -54,7 +54,7 @@ impl StdError for Error {
     }
 }
 
-impl fmt::Display for Error {
+impl fmt::Display for GuardError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} (required: {}, actual: {})", self.description(), self.required, self.actual)
     }

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -1,0 +1,90 @@
+use error::{GuardError, ErrorReason};
+use std::mem::align_of;
+
+/// The `Guard` type describes types which define boundary checking strategies.
+pub trait Guard {
+    fn check<T>(v: &[u8]) -> Result<(), GuardError>;
+}
+
+/// Single value guard: The byte slice must have exactly enough bytes to fill a single
+/// instance of a type.
+pub struct SingleValueGuard;
+impl Guard for SingleValueGuard {
+    fn check<T>(bytes: &[u8]) -> Result<(), GuardError> {
+        if bytes.len() != align_of::<T>() {
+            Err(GuardError {
+                required: align_of::<T>(),
+                actual: bytes.len(),
+                reason: ErrorReason::InexactByteCount,
+            })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Pedantic guard: The byte slice must have at least enough bytes to fill a single
+/// instance of a type, and should not have extraneous data.
+pub struct PedanticGuard;
+impl Guard for PedanticGuard {
+    fn check<T>(bytes: &[u8]) -> Result<(), GuardError> {
+        if bytes.len() < align_of::<T>() {
+            Err(GuardError {
+                required: align_of::<T>(),
+                actual: bytes.len(),
+                reason: ErrorReason::NotEnoughBytes,
+            })
+        } else if bytes.len() % align_of::<T>() != 0 {
+            Err(GuardError {
+                required: align_of::<T>(),
+                actual: bytes.len(),
+                reason: ErrorReason::InexactByteCount,
+            })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// A strict guard: The byte slice should not have extraneous data, but can be empty.
+pub struct StrictGuard;
+impl Guard for StrictGuard {
+    fn check<T>(bytes: &[u8]) -> Result<(), GuardError> {
+        if bytes.len() % align_of::<T>() != 0 {
+            Err(GuardError {
+                required: align_of::<T>(),
+                actual: bytes.len(),
+                reason: ErrorReason::InexactByteCount,
+            })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// A basic reasonable guard: The byte slice must have at least enough bytes to fill a single
+/// instance of a type, and extraneous data is ignored.
+pub struct BasicGuard;
+impl Guard for BasicGuard {
+    fn check<T>(bytes: &[u8]) -> Result<(), GuardError> {
+        if bytes.len() < align_of::<T>() {
+            Err(GuardError {
+                required: align_of::<T>(),
+                actual: bytes.len(),
+                reason: ErrorReason::NotEnoughBytes,
+            })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Permissive guard: The resulting slice will have as many instances of a type as will
+/// fit, rounded down. Therefore, this guard will never yield an error.
+pub struct PermissiveGuard;
+impl Guard for PermissiveGuard {
+    #[inline]
+    fn check<T>(_bytes: &[u8]) -> Result<(), GuardError> {
+        Ok(())
+    }
+}

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -1,8 +1,77 @@
-use error::{GuardError, ErrorReason};
+//! The `guard` module exposes an API for memory boundary checking.
+//!
+//! # Examples:
+//!
+//! In order to check whether a value would fit in the given
+//! slice without extraneous space:
+//!
+//! ```
+//! # use safe_transmute::Error;
+//! # use safe_transmute::guard::{Guard, SingleValueGuard};
+//! # fn run() -> Result<(), Error> {
+//! SingleValueGuard::check::<u32>(&[0x00, 0x01, 0x00, 0x02])?;
+//! # Ok(())
+//! # }
+//! # run().unwrap();
+//! ```
+//!
+//! Different guard types implement different checking strategies.
+//! For example, the pedantic guard type [`PedanticGuard`] requires
+//! the slice to have space for at least one value, and not have
+//! extraneous bytes at the end.
+//!
+//!
+//! ```
+//! # use safe_transmute::Error;
+//! # use safe_transmute::guard::{Guard, PedanticGuard};
+//! # fn run() -> Result<(), Error> {
+//! PedanticGuard::check::<u16>(&[0xAA, 0xAA, 0xBB, 0xBB, 0xCC, 0xCC])?;
+//! # Ok(())
+//! # }
+//! # run().unwrap();
+//! ```
+//!
+//! [`PermissiveGuard`], on the other hand, will accept any memory slice.
+//!
+//! ```
+//! # use safe_transmute::Error;
+//! # use safe_transmute::guard::{Guard, PermissiveGuard};
+//! # fn run() -> Result<(), Error> {
+//! PermissiveGuard::check::<i16>(b"covfefe")?;
+//! # Ok(())
+//! # }
+//! # run().unwrap();
+//! ```
+//!
+//! If the check fails, the resulting [`GuardError`] value describes why.
+//!
+//! ```
+//! # use safe_transmute::{GuardError, ErrorReason};
+//! # use safe_transmute::guard::{Guard, PedanticGuard};
+//! assert_eq!(
+//!     PedanticGuard::check::<i16>(b"covfefe"),
+//!     Err(GuardError {
+//!         required: 2,
+//!         actual: 7,
+//!         reason: ErrorReason::InexactByteCount,
+//!     }));
+//! ```
+//!
+//! [`GuardError`]: ../type.GuardError.html
+//! [`PedanticGuard`]: struct.PedanticGuard.html
+//! [`PermissiveGuard`]: struct.PermissiveGuard.html
+
+use error::{ErrorReason, GuardError};
 use std::mem::align_of;
 
 /// The `Guard` type describes types which define boundary checking strategies.
 pub trait Guard {
+    /// Check the size of the given byte slice against a particular type.
+    ///
+    /// # Errors
+    ///
+    /// If the slice's size does not comply with this guard, an error
+    /// which specifies the incompatibility is returned.
     fn check<T>(v: &[u8]) -> Result<(), GuardError>;
 }
 
@@ -46,7 +115,8 @@ impl Guard for PedanticGuard {
     }
 }
 
-/// A strict guard: The byte slice should not have extraneous data, but can be empty.
+/// A strict guard: The byte slice should not have extraneous data, but can be
+/// empty.
 pub struct StrictGuard;
 impl Guard for StrictGuard {
     fn check<T>(bytes: &[u8]) -> Result<(), GuardError> {
@@ -79,7 +149,7 @@ impl Guard for BasicGuard {
     }
 }
 
-/// Permissive guard: The resulting slice will have as many instances of a type as will
+/// Permissive guard: The resulting slice would have as many instances of a type as will
 /// fit, rounded down. Therefore, this guard will never yield an error.
 pub struct PermissiveGuard;
 impl Guard for PermissiveGuard {

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -20,7 +20,6 @@
 //! the slice to have space for at least one value, and not have
 //! extraneous bytes at the end.
 //!
-//!
 //! ```
 //! # use safe_transmute::Error;
 //! # use safe_transmute::guard::{Guard, PedanticGuard};
@@ -48,13 +47,12 @@
 //! ```
 //! # use safe_transmute::{GuardError, ErrorReason};
 //! # use safe_transmute::guard::{Guard, PedanticGuard};
-//! assert_eq!(
-//!     PedanticGuard::check::<i16>(b"covfefe"),
-//!     Err(GuardError {
-//!         required: 2,
-//!         actual: 7,
-//!         reason: ErrorReason::InexactByteCount,
-//!     }));
+//! assert_eq!(PedanticGuard::check::<i16>(b"covfefe"),
+//!            Err(GuardError {
+//!                required: 2,
+//!                actual: 7,
+//!                reason: ErrorReason::InexactByteCount,
+//!            }));
 //! ```
 //!
 //! [`GuardError`]: ../type.GuardError.html
@@ -78,6 +76,7 @@ pub trait Guard {
 /// Single value guard: The byte slice must have exactly enough bytes to fill a single
 /// instance of a type.
 pub struct SingleValueGuard;
+
 impl Guard for SingleValueGuard {
     fn check<T>(bytes: &[u8]) -> Result<(), GuardError> {
         if bytes.len() != align_of::<T>() {
@@ -95,6 +94,7 @@ impl Guard for SingleValueGuard {
 /// Pedantic guard: The byte slice must have at least enough bytes to fill a single
 /// instance of a type, and should not have extraneous data.
 pub struct PedanticGuard;
+
 impl Guard for PedanticGuard {
     fn check<T>(bytes: &[u8]) -> Result<(), GuardError> {
         if bytes.len() < align_of::<T>() {
@@ -115,10 +115,11 @@ impl Guard for PedanticGuard {
     }
 }
 
-/// A strict guard: The byte slice should not have extraneous data, but can be
-/// empty.
-pub struct StrictGuard;
-impl Guard for StrictGuard {
+/// An all-or-nothing guard: The byte slice should not have extraneous data, but can be
+/// empty, unlike `PedanticGuard`.
+pub struct AllOrNothingGuard;
+
+impl Guard for AllOrNothingGuard {
     fn check<T>(bytes: &[u8]) -> Result<(), GuardError> {
         if bytes.len() % align_of::<T>() != 0 {
             Err(GuardError {
@@ -132,10 +133,11 @@ impl Guard for StrictGuard {
     }
 }
 
-/// A basic reasonable guard: The byte slice must have at least enough bytes to fill a single
+/// A single-or-many guard: The byte slice must have at least enough bytes to fill a single
 /// instance of a type, and extraneous data is ignored.
-pub struct BasicGuard;
-impl Guard for BasicGuard {
+pub struct SingleManyGuard;
+
+impl Guard for SingleManyGuard {
     fn check<T>(bytes: &[u8]) -> Result<(), GuardError> {
         if bytes.len() < align_of::<T>() {
             Err(GuardError {
@@ -152,9 +154,10 @@ impl Guard for BasicGuard {
 /// Permissive guard: The resulting slice would have as many instances of a type as will
 /// fit, rounded down. Therefore, this guard will never yield an error.
 pub struct PermissiveGuard;
+
 impl Guard for PermissiveGuard {
     #[inline]
-    fn check<T>(_bytes: &[u8]) -> Result<(), GuardError> {
+    fn check<T>(_: &[u8]) -> Result<(), GuardError> {
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ mod error;
 
 use std::slice;
 use std::mem::{align_of, forget};
+use guard::{Guard, PedanticGuard, PermissiveGuard, SingleManyGuard, SingleValueGuard};
 
 pub mod guard;
 pub mod util;
@@ -82,7 +83,6 @@ pub use self::pod::{guarded_transmute_pod, guarded_transmute_pod_many, guarded_t
                     PodTransmutable};
 pub use self::bool::{guarded_transmute_bool_pedantic, guarded_transmute_bool_permissive, guarded_transmute_bool_vec_pedantic,
                      guarded_transmute_bool_vec_permissive};
-use guard::*;
 
 /// Transmute a byte slice into a single instance of a `Copy`able type.
 ///
@@ -105,7 +105,7 @@ use guard::*;
 /// # }
 /// ```
 pub unsafe fn guarded_transmute<T: Copy>(bytes: &[u8]) -> Result<T, Error> {
-    BasicGuard::check::<T>(bytes)?;
+    SingleManyGuard::check::<T>(bytes)?;
     Ok(slice::from_raw_parts(bytes.as_ptr() as *const T, 1)[0])
 }
 
@@ -155,7 +155,7 @@ pub unsafe fn guarded_transmute_pedantic<T: Copy>(bytes: &[u8]) -> Result<T, Err
 /// # }
 /// ```
 pub unsafe fn guarded_transmute_many<T>(bytes: &[u8]) -> Result<&[T], Error> {
-    BasicGuard::check::<T>(bytes)?;
+    SingleManyGuard::check::<T>(bytes)?;
     Ok(slice::from_raw_parts(bytes.as_ptr() as *const T, bytes.len() / align_of::<T>()))
 }
 
@@ -232,7 +232,7 @@ pub unsafe fn guarded_transmute_many_pedantic<T>(bytes: &[u8]) -> Result<&[T], E
 /// # }
 /// ```
 pub unsafe fn guarded_transmute_vec<T>(bytes: Vec<u8>) -> Result<Vec<T>, Error> {
-    BasicGuard::check::<T>(&bytes)?;
+    SingleManyGuard::check::<T>(&bytes)?;
     Ok(guarded_transmute_vec_permissive(bytes))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,13 +76,12 @@ use std::mem::{align_of, forget};
 pub mod guard;
 pub mod util;
 
-pub use self::error::{ErrorReason, Error};
-pub use self::pod::{PodTransmutable, guarded_transmute_pod_many_permissive, guarded_transmute_pod_vec_permissive, guarded_transmute_pod_many_pedantic,
-                    guarded_transmute_pod_pedantic, guarded_transmute_pod_vec_pedantic, guarded_transmute_pod_many, guarded_transmute_pod,
-                    guarded_transmute_pod_vec};
-pub use self::bool::{guarded_transmute_bool_vec_permissive, guarded_transmute_bool_vec_pedantic, guarded_transmute_bool_permissive,
-                     guarded_transmute_bool_pedantic};
-
+pub use self::error::{Error, ErrorReason, GuardError};
+pub use self::pod::{guarded_transmute_pod, guarded_transmute_pod_many, guarded_transmute_pod_many_pedantic, guarded_transmute_pod_many_permissive,
+                    guarded_transmute_pod_pedantic, guarded_transmute_pod_vec, guarded_transmute_pod_vec_pedantic, guarded_transmute_pod_vec_permissive,
+                    PodTransmutable};
+pub use self::bool::{guarded_transmute_bool_pedantic, guarded_transmute_bool_permissive, guarded_transmute_bool_vec_pedantic,
+                     guarded_transmute_bool_vec_permissive};
 use guard::*;
 
 /// Transmute a byte slice into a single instance of a `Copy`able type.


### PR DESCRIPTION
This is a refactor that moves all bounds checking strategies to the `guard` module. It doesn't change the public APIs (other than the fact that `guard` is public), but it may become a crucial part of the API in the future.