### PR TITLE
Add some funcitons to transform from concrete types to [u8]s

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,11 +64,29 @@
 //! # }
 //! # }
 //! ```
+//!
+//! View a series of `u16`s as bytes:
+//!
+//! ```
+//! # use safe_transmute::guarded_transmute_to_bytes_pod_many;
+//! # include!("../tests/test_util/le_to_native.rs");
+//! # fn main() {
+//! # unsafe {
+//! assert_eq!(guarded_transmute_to_bytes_pod_many(&[0x0001u16,
+//!                                                  0x1234u16]),
+//! # /*
+//!            &[0x01, 0x00, 0x34, 0x12].le_to_native::<u16>());
+//! # */
+//! #          &[0x01, 0x00, 0x34, 0x12].le_to_native::<u16>());
+//! # }
+//! # }
+//! ```
 
 
 mod pod;
 mod bool;
 mod error;
+mod to_bytes;
 
 use std::slice;
 use std::mem::{size_of, forget};
@@ -78,6 +96,7 @@ pub mod util;
 pub mod guard;
 
 pub use self::error::{Error, ErrorReason, GuardError};
+pub use self::to_bytes::{guarded_transmute_to_bytes_pod_many, guarded_transmute_to_bytes_many, guarded_transmute_to_bytes_pod, guarded_transmute_to_bytes};
 pub use self::pod::{PodTransmutable, guarded_transmute_pod_many_permissive, guarded_transmute_pod_vec_permissive, guarded_transmute_pod_many_pedantic,
                     guarded_transmute_pod_vec_pedantic, guarded_transmute_pod_pedantic, guarded_transmute_pod_many, guarded_transmute_pod_vec,
                     guarded_transmute_pod};

--- a/src/to_bytes.rs
+++ b/src/to_bytes.rs
@@ -1,0 +1,177 @@
+//! Functions for transmutation *from* a concrete type *to* bytes.
+
+
+use self::super::PodTransmutable;
+use std::mem::size_of;
+use std::slice;
+
+
+/// Transmute a single instance of an arbitrary type into a slice of its bytes.
+///
+/// # Examples
+///
+/// An `u32`:
+///
+/// ```
+/// # use safe_transmute::guarded_transmute_to_bytes;
+/// # include!("../tests/test_util/le_to_native.rs");
+/// # fn main() {
+/// # unsafe {
+/// assert_eq!(guarded_transmute_to_bytes(&0x01234567),
+/// # /*
+///            &[0x67, 0x45, 0x23, 0x01]);
+/// # */
+/// #           [0x67, 0x45, 0x23, 0x01].le_to_native::<u32>());
+/// # }
+/// # }
+/// ```
+///
+/// An arbitrary type:
+///
+/// ```
+/// # use safe_transmute::guarded_transmute_to_bytes;
+/// #[repr(C)]
+/// struct Gene {
+///     x1: u8,
+///     x2: u8,
+/// }
+///
+/// # unsafe {
+/// assert_eq!(guarded_transmute_to_bytes(&Gene {
+///                x1: 0x42,
+///                x2: 0x69,
+///            }),
+///            &[0x42, 0x69]);
+/// # }
+/// ```
+pub unsafe fn guarded_transmute_to_bytes<T>(from: &T) -> &[u8] {
+    slice::from_raw_parts(from as *const T as *const u8, size_of::<T>())
+}
+
+/// Transmute a slice of arbitrary types into a slice of their bytes.
+///
+/// # Examples
+///
+/// Some `u16`s:
+///
+/// ```
+/// # use safe_transmute::guarded_transmute_to_bytes;
+/// # include!("../tests/test_util/le_to_native.rs");
+/// # fn main() {
+/// # unsafe {
+/// assert_eq!(guarded_transmute_to_bytes(&[0x0123u16, 0x4567u16]),
+/// # /*
+///            &[0x23, 0x01, 0x67, 0x45]);
+/// # */
+/// #           [0x23, 0x01, 0x67, 0x45].le_to_native::<u16>());
+/// # }
+/// # }
+/// ```
+///
+/// An arbitrary type:
+///
+/// ```
+/// # use safe_transmute::{PodTransmutable, guarded_transmute_to_bytes_many};
+/// #[repr(C)]
+/// struct Gene {
+///     x1: u8,
+///     x2: u8,
+/// }
+///
+/// # unsafe {
+/// assert_eq!(guarded_transmute_to_bytes_many(&[Gene {
+///                                                  x1: 0x42,
+///                                                  x2: 0x69,
+///                                              },
+///                                              Gene {
+///                                                  x1: 0x12,
+///                                                  x2: 0x48,
+///                                              }]),
+///            &[0x42, 0x69, 0x12, 0x48]);
+/// # }
+/// ```
+pub unsafe fn guarded_transmute_to_bytes_many<T>(from: &[T]) -> &[u8] {
+    slice::from_raw_parts(from.as_ptr() as *const u8, from.len() * size_of::<T>())
+}
+
+/// Transmute a single instance of a POD type into a slice of its bytes.
+///
+/// # Examples
+///
+/// An `u32`:
+///
+/// ```
+/// # use safe_transmute::guarded_transmute_to_bytes_pod;
+/// # include!("../tests/test_util/le_to_native.rs");
+/// # fn main() {
+/// assert_eq!(guarded_transmute_to_bytes_pod(&0x01234567),
+/// # /*
+///            &[0x67, 0x45, 0x23, 0x01]);
+/// # */
+/// #           [0x67, 0x45, 0x23, 0x01].le_to_native::<u32>());
+/// # }
+/// ```
+///
+/// An arbitrary type:
+///
+/// ```
+/// # use safe_transmute::{PodTransmutable, guarded_transmute_to_bytes_pod};
+/// #[repr(C)]
+/// struct Gene {
+///     x1: u8,
+///     x2: u8,
+/// }
+/// unsafe impl PodTransmutable for Gene {}
+///
+/// assert_eq!(guarded_transmute_to_bytes_pod(&Gene {
+///                x1: 0x42,
+///                x2: 0x69,
+///            }),
+///            &[0x42, 0x69]);
+/// ```
+pub fn guarded_transmute_to_bytes_pod<T: PodTransmutable>(from: &T) -> &[u8] {
+    unsafe { guarded_transmute_to_bytes(from) }
+}
+
+/// Transmute a slice of arbitrary types into a slice of their bytes.
+///
+/// # Examples
+///
+/// Some `u16`s:
+///
+/// ```
+/// # use safe_transmute::guarded_transmute_to_bytes_pod_many;
+/// # include!("../tests/test_util/le_to_native.rs");
+/// # fn main() {
+/// assert_eq!(guarded_transmute_to_bytes_pod_many(&[0x0123u16, 0x4567u16]),
+/// # /*
+///            &[0x23, 0x01, 0x67, 0x45]);
+/// # */
+/// #           [0x23, 0x01, 0x67, 0x45].le_to_native::<u16>());
+/// # }
+/// ```
+///
+/// An arbitrary type:
+///
+/// ```
+/// # use safe_transmute::{PodTransmutable, guarded_transmute_to_bytes_pod_many};
+/// #[repr(C)]
+/// struct Gene {
+///     x1: u8,
+///     x2: u8,
+/// }
+/// unsafe impl PodTransmutable for Gene {}
+///
+/// assert_eq!(guarded_transmute_to_bytes_pod_many(&[Gene {
+///                                                      x1: 0x42,
+///                                                      x2: 0x69,
+///                                                  },
+///                                                  Gene {
+///                                                      x1: 0x12,
+///                                                      x2: 0x48,
+///                                                  }]),
+///            &[0x42, 0x69, 0x12, 0x48]);
+/// ```
+pub fn guarded_transmute_to_bytes_pod_many<T: PodTransmutable>(from: &[T]) -> &[u8] {
+    unsafe { guarded_transmute_to_bytes_many(from) }
+}


### PR DESCRIPTION
Now you can go from any type to its bytes. If you `unsafe impl` `PodTransmutable` therefor, you can even do so safely, with `pod` functions.

Ref: @frankier
Closes #17