### PR TITLE
Add guarded transmute to mut bytes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ pub mod util;
 pub mod guard;
 
 pub use self::error::{Error, ErrorReason, GuardError};
-pub use self::to_bytes::{guarded_transmute_to_bytes_pod_many, guarded_transmute_to_bytes_many, guarded_transmute_to_bytes_pod, guarded_transmute_to_bytes};
+pub use self::to_bytes::{guarded_transmute_to_bytes_pod_many, guarded_transmute_to_bytes_many, guarded_transmute_to_bytes_pod, guarded_transmute_to_bytes, guarded_transmute_to_mut_bytes_pod, guarded_transmute_to_mut_bytes};
 pub use self::pod::{PodTransmutable, guarded_transmute_pod_many_permissive, guarded_transmute_pod_vec_permissive, guarded_transmute_pod_many_pedantic,
                     guarded_transmute_pod_vec_pedantic, guarded_transmute_pod_pedantic, guarded_transmute_pod_many, guarded_transmute_pod_vec,
                     guarded_transmute_pod};

--- a/src/to_bytes.rs
+++ b/src/to_bytes.rs
@@ -48,6 +48,11 @@ pub unsafe fn guarded_transmute_to_bytes<T>(from: &T) -> &[u8] {
     slice::from_raw_parts(from as *const T as *const u8, size_of::<T>())
 }
 
+/// Transmute a single instance of an arbitrary type into a mutable slice of its bytes.
+pub unsafe fn guarded_transmute_to_mut_bytes<T>(from: &mut T) -> &mut [u8] {
+    slice::from_raw_parts_mut(from as *mut T as *mut u8, size_of::<T>())
+}
+
 /// Transmute a slice of arbitrary types into a slice of their bytes.
 ///
 /// # Examples
@@ -174,4 +179,8 @@ pub fn guarded_transmute_to_bytes_pod<T: PodTransmutable>(from: &T) -> &[u8] {
 /// ```
 pub fn guarded_transmute_to_bytes_pod_many<T: PodTransmutable>(from: &[T]) -> &[u8] {
     unsafe { guarded_transmute_to_bytes_many(from) }
+}
+
+pub fn guarded_transmute_to_mut_bytes_pod<T: PodTransmutable>(from: &mut T) -> &mut [u8] {
+    unsafe { guarded_transmute_to_mut_bytes(from) }
 }


### PR DESCRIPTION
Further to https://github.com/nabijaczleweli/safe-transmute-rs/issues/17

After some quick testing, it seems that transmute does do the correct thing with mutable references. For example:

This doesn't work: https://play.rust-lang.org/?gist=1ff0495b84b12268e97ccf4defaf164f&version=stable

But this does: https://play.rust-lang.org/?gist=7c7b4cb6e87f405bb97806ef69835a8c&version=stable

So it seems like it should also be safe to allow guarded transmutes into mutable references as done here.

Does it seem like a reasonable idea? As with https://github.com/nabijaczleweli/safe-transmute-rs/issues/9 it's possible these functions could be organised a bit better.