### PR TITLE
Require `Copy` for `PodTransmutable`

### DIFF
--- a/src/pod.rs
+++ b/src/pod.rs
@@ -19,11 +19,11 @@ use self::super::{Error, guarded_transmute_many_permissive, guarded_transmute_ve
 /// # Safety
 ///
 /// It is only safe to implement `PodTransmutable` for a type `T` if it is safe for a slice of any arbitrary data
-/// `&[u8]` of length `sizeof<T>()` to be [`transmute()`]((https://doc.rust-lang.org/stable/std/mem/fn.transmute.html)d
+/// `&[u8]` of length `sizeof<T>()` to be [`transmute()`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html)d
 /// to a unit-length `&[T]`.
 ///
 /// Consult the [Transmutes section](https://doc.rust-lang.org/nomicon/transmutes.html) of the Nomicon for more details.
-pub unsafe trait PodTransmutable {}
+pub unsafe trait PodTransmutable: Copy {}
 
 
 unsafe impl PodTransmutable for u8 {}
@@ -61,7 +61,7 @@ unsafe impl PodTransmutable for i128 {}
 /// # assert_eq!(guarded_transmute_pod::<u32>(&[0x00, 0x00, 0x00, 0x01].le_to_native::<u32>()).unwrap(), 0x01000000);
 /// # }
 /// ```
-pub fn guarded_transmute_pod<T: PodTransmutable + Copy>(bytes: &[u8]) -> Result<T, Error> {
+pub fn guarded_transmute_pod<T: PodTransmutable>(bytes: &[u8]) -> Result<T, Error> {
     unsafe { guarded_transmute(bytes) }
 }
 
@@ -82,7 +82,7 @@ pub fn guarded_transmute_pod<T: PodTransmutable + Copy>(bytes: &[u8]) -> Result<
 /// # assert_eq!(guarded_transmute_pod_pedantic::<u16>(&[0x0F, 0x0E].le_to_native::<u16>()).unwrap(), 0x0E0F);
 /// # }
 /// ```
-pub fn guarded_transmute_pod_pedantic<T: PodTransmutable + Copy>(bytes: &[u8]) -> Result<T, Error> {
+pub fn guarded_transmute_pod_pedantic<T: PodTransmutable>(bytes: &[u8]) -> Result<T, Error> {
     unsafe { guarded_transmute_pedantic(bytes) }
 }
 

--- a/src/to_bytes.rs
+++ b/src/to_bytes.rs
@@ -117,6 +117,7 @@ pub unsafe fn guarded_transmute_to_bytes_many<T>(from: &[T]) -> &[u8] {
 /// ```
 /// # use safe_transmute::{PodTransmutable, guarded_transmute_to_bytes_pod};
 /// #[repr(C)]
+/// #[derive(Clone, Copy)]
 /// struct Gene {
 ///     x1: u8,
 ///     x2: u8,
@@ -156,6 +157,7 @@ pub fn guarded_transmute_to_bytes_pod<T: PodTransmutable>(from: &T) -> &[u8] {
 /// ```
 /// # use safe_transmute::{PodTransmutable, guarded_transmute_to_bytes_pod_many};
 /// #[repr(C)]
+/// #[derive(Clone, Copy)]
 /// struct Gene {
 ///     x1: u8,
 ///     x2: u8,


### PR DESCRIPTION
I believe this has been discussed before. I really can't think of any situation where implementing `PodTransmutable` would be safe without having `Copy` to start with (the whole idea even emerged from C++'s concept of _trivially copiable_).

This _is_ a breaking change, although not a serious one.