### PR TITLE
Add a few tests containing unaligned slicing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ before_script:
 script:
   - cargo build --verbose
   - if [ ! -z "$CROSS_TARGET" ]; then
-      cross test --verbose --target $CROSS_TARGET;
+      cross test --verbose --target $CROSS_TARGET --features test-unaligned;
     else
-      cargo test --verbose;
+      cargo test --verbose --features test-unaligned;
     fi
   - if [ "$CLIPPY" ]; then
       cargo install -f clippy;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ version = "0.8.0"
 authors = ["nabijaczleweli <nabijaczleweli@gmail.com>",
            "Eduardo Pinho <enet4mikeenet@gmail.com>"]
 exclude = ["*.enc"]
+
+[features]
+"test-unaligned" = []

--- a/tests/guarded_transmute_many/mod.rs
+++ b/tests/guarded_transmute_many/mod.rs
@@ -65,3 +65,28 @@ fn misaligned_slicing() {
                    Ok([0xCC03DD02, 0xAA05BB04].into_iter().as_slice()));
     }
 }
+
+
+#[cfg(target_endian = "big")]
+#[test]
+fn misaligned_slicing() {
+    let bytes = &[0xFF, 0x01, 0xEE, 0x02, 0xDD, 0x03, 0xCC];
+    unsafe {
+        assert_eq!(guarded_transmute_many::<u16>(bytes),
+                   Ok([0xFF01, 0xEE02, 0xDD03].into_iter().as_slice()));
+        assert_eq!(guarded_transmute_many::<u16>(&bytes[1..]),
+                   Ok([0x01EE, 0x02DD, 0x03CC].into_iter().as_slice()));
+    }
+
+    let bytes: &[u8] = &[0xFF, 0x01, 0xEE, 0x02, 0xDD, 0x03, 0xCC, 0x04, 0xBB, 0x05, 0xAA, 0x06];
+    unsafe {
+        assert_eq!(guarded_transmute_many::<u32>(bytes),
+                   Ok([0xFF01EE02, 0xDD03CC04, 0xBB05AA06].into_iter().as_slice()));
+        assert_eq!(guarded_transmute_many::<u32>(&bytes[1..]),
+                   Ok([0x01EE02DD, 0x03CC04BB].into_iter().as_slice()));
+        assert_eq!(guarded_transmute_many::<u32>(&bytes[2..]),
+                   Ok([0xEE02DD03, 0xCC04BB05].into_iter().as_slice()));
+        assert_eq!(guarded_transmute_many::<u32>(&bytes[3..]),
+                   Ok([0x02DD03CC, 0x04BB05AA].into_iter().as_slice()));
+    }
+}

--- a/tests/guarded_transmute_many/mod.rs
+++ b/tests/guarded_transmute_many/mod.rs
@@ -41,3 +41,27 @@ fn too_much() {
                    Ok([0x0100u16, 0x0200u16, 0x0300u16].into_iter().as_slice()));
     }
 }
+
+#[cfg(target_endian = "little")]
+#[test]
+fn misaligned_slicing() {
+    let bytes = &[0xFF, 0x01, 0xEE, 0x02, 0xDD, 0x03, 0xCC];
+    unsafe {
+        assert_eq!(guarded_transmute_many::<u16>(bytes),
+                   Ok([0x01FF, 0x02EE, 0x03DD].into_iter().as_slice()));
+        assert_eq!(guarded_transmute_many::<u16>(&bytes[1..]),
+                   Ok([0xEE01, 0xDD02, 0xCC03].into_iter().as_slice()));
+    }
+
+    let bytes: &[u8] = &[0xFF, 0x01, 0xEE, 0x02, 0xDD, 0x03, 0xCC, 0x04, 0xBB, 0x05, 0xAA, 0x06];
+    unsafe {
+        assert_eq!(guarded_transmute_many::<u32>(bytes),
+                   Ok([0x02EE01FF, 0x04CC03DD, 0x06AA05BB].into_iter().as_slice()));
+        assert_eq!(guarded_transmute_many::<u32>(&bytes[1..]),
+                   Ok([0xDD02EE01, 0xBB04CC03].into_iter().as_slice()));
+        assert_eq!(guarded_transmute_many::<u32>(&bytes[2..]),
+                   Ok([0x03DD02EE, 0x05BB04CC].into_iter().as_slice()));
+        assert_eq!(guarded_transmute_many::<u32>(&bytes[3..]),
+                   Ok([0xCC03DD02, 0xAA05BB04].into_iter().as_slice()));
+    }
+}

--- a/tests/guarded_transmute_many/mod.rs
+++ b/tests/guarded_transmute_many/mod.rs
@@ -42,9 +42,10 @@ fn too_much() {
     }
 }
 
+#[cfg(feature = "test-unaligned")]
 #[cfg(target_endian = "little")]
 #[test]
-fn misaligned_slicing() {
+fn unaligned_slicing() {
     let bytes = &[0xFF, 0x01, 0xEE, 0x02, 0xDD, 0x03, 0xCC];
     unsafe {
         assert_eq!(guarded_transmute_many::<u16>(bytes),
@@ -67,9 +68,10 @@ fn misaligned_slicing() {
 }
 
 
+#[cfg(feature = "test-unaligned")]
 #[cfg(target_endian = "big")]
 #[test]
-fn misaligned_slicing() {
+fn unaligned_slicing() {
     let bytes = &[0xFF, 0x01, 0xEE, 0x02, 0xDD, 0x03, 0xCC];
     unsafe {
         assert_eq!(guarded_transmute_many::<u16>(bytes),


### PR DESCRIPTION
See if you're interested in this test I made a while ago. Basically, I was wondering about whether the slice had to be properly aligned in memory (according to the target type `T`) for a successful read of the transmuted content. They happen to pass on a Linux-x86_64, although I know this doesn't prove much. This actually comes up as surprising: AFAIK some CPU architectures won't let you read misaligned words.

If you approve, we may also make the respective Big Endian version of the test, and so check out whether MIPS64 would tolerate it.