### PR TITLE
Adjust error types for future updates

### DIFF
--- a/src/bool.rs
+++ b/src/bool.rs
@@ -4,7 +4,7 @@
 //! behind the `bool` value is neither one.
 
 
-use self::super::{ErrorReason, Error, guarded_transmute_many_permissive, guarded_transmute_vec_permissive, guarded_transmute_many_pedantic,
+use self::super::{Error, guarded_transmute_many_permissive, guarded_transmute_vec_permissive, guarded_transmute_many_pedantic,
                   guarded_transmute_vec_pedantic};
 use std::mem::size_of;
 
@@ -92,7 +92,7 @@ pub fn guarded_transmute_bool_vec_permissive(bytes: Vec<u8>) -> Result<Vec<bool>
     unsafe { Ok(guarded_transmute_vec_permissive(bytes)) }
 }
 
-/// Trasform a byte vector into a vector of bool.
+/// Transform a byte vector into a vector of bool.
 ///
 /// The vector's allocated byte buffer will be reused when possible, and
 /// should not have extraneous data.
@@ -122,10 +122,6 @@ fn check_bool(bytes: &[u8]) -> Result<(), Error> {
     if bytes_are_bool(bytes) {
         Ok(())
     } else {
-        Err(Error {
-            required: size_of::<bool>(),
-            actual: bytes.len(),
-            reason: ErrorReason::InvalidValue,
-        })
+        Err(Error::InvalidValue)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,7 +43,7 @@ impl StdError for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Guard(ref e) => fmt::Display::fmt(e, f),
+            Error::Guard(ref e) => e.fmt(f),
             Error::Unaligned { offset } => write!(f, "{} (off by {} bytes)", self.description(), offset),
             Error::InvalidValue => write!(f, "{}", self.description()),
         }

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -30,7 +30,7 @@
 //! # run().unwrap();
 //! ```
 //!
-//! [`PermissiveGuard`](struct.PermissiveGuard.html, on the other hand, will accept any memory slice.
+//! [`PermissiveGuard`](struct.PermissiveGuard.html), on the other hand, will accept any memory slice.
 //!
 //! ```
 //! # use safe_transmute::Error;
@@ -65,7 +65,7 @@ use std::mem::size_of;
 
 
 /// The trait describes types which define boundary checking strategies.
-/// See the [module-level documentation](./index.html) for more details.
+/// See the [module-level documentation](index.html) for more details.
 pub trait Guard {
     /// Check the size of the given byte slice against a particular type.
     ///

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -54,13 +54,18 @@
 //!                reason: ErrorReason::InexactByteCount,
 //!            }));
 //! ```
+//! 
+//! Regardless of the chosen strategy, guarded transmutation functions will
+//! always ensure that no out of bounds access is attempted, usually by
+//! restricting the output to spatially safe portions of the input.
 
 
 use error::{ErrorReason, GuardError};
 use std::mem::size_of;
 
 
-/// The `Guard` type describes types which define boundary checking strategies.
+/// The trait describes types which define boundary checking strategies.
+/// See the [module-level documentation](./index.html) for more details.
 pub trait Guard {
     /// Check the size of the given byte slice against a particular type.
     ///

--- a/tests/guarded_transmute/mod.rs
+++ b/tests/guarded_transmute/mod.rs
@@ -1,4 +1,4 @@
-use safe_transmute::{ErrorReason, Error, guarded_transmute};
+use safe_transmute::{ErrorReason, Error, GuardError, guarded_transmute};
 use self::super::LeToNative;
 
 
@@ -6,17 +6,17 @@ use self::super::LeToNative;
 fn too_short() {
     unsafe {
         assert_eq!(guarded_transmute::<u32>(&[]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 32 / 8,
                        actual: 0,
                        reason: ErrorReason::NotEnoughBytes,
-                   }));
+                   })));
         assert_eq!(guarded_transmute::<u32>(&[0x00]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 32 / 8,
                        actual: 1,
                        reason: ErrorReason::NotEnoughBytes,
-                   }));
+                   })));
     }
 }
 

--- a/tests/guarded_transmute_bool_pedantic/mod.rs
+++ b/tests/guarded_transmute_bool_pedantic/mod.rs
@@ -1,14 +1,14 @@
-use safe_transmute::{ErrorReason, Error, guarded_transmute_bool_pedantic};
+use safe_transmute::{ErrorReason, Error, GuardError, guarded_transmute_bool_pedantic};
 
 
 #[test]
 fn too_short() {
     assert_eq!(guarded_transmute_bool_pedantic([].as_ref()),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 1,
                    actual: 0,
                    reason: ErrorReason::NotEnoughBytes,
-               }));
+               })));
 }
 
 #[test]
@@ -22,21 +22,9 @@ fn just_enough() {
 #[test]
 fn invalid_bytes() {
     assert_eq!(guarded_transmute_bool_pedantic([0x00, 0x01, 0x02].as_ref()),
-               Err(Error {
-                   required: 1,
-                   actual: 3,
-                   reason: ErrorReason::InvalidValue,
-               }));
+               Err(Error::InvalidValue));
     assert_eq!(guarded_transmute_bool_pedantic([0x05, 0x01, 0x00].as_ref()),
-               Err(Error {
-                   required: 1,
-                   actual: 3,
-                   reason: ErrorReason::InvalidValue,
-               }));
+               Err(Error::InvalidValue));
     assert_eq!(guarded_transmute_bool_pedantic([0xFF].as_ref()),
-               Err(Error {
-                   required: 1,
-                   actual: 1,
-                   reason: ErrorReason::InvalidValue,
-               }));
+               Err(Error::InvalidValue));
 }

--- a/tests/guarded_transmute_bool_permissive/mod.rs
+++ b/tests/guarded_transmute_bool_permissive/mod.rs
@@ -1,4 +1,4 @@
-use safe_transmute::{ErrorReason, Error, guarded_transmute_bool_permissive};
+use safe_transmute::{Error, guarded_transmute_bool_permissive};
 
 
 #[test]
@@ -16,21 +16,9 @@ fn just_enough() {
 #[test]
 fn invalid_bytes() {
     assert_eq!(guarded_transmute_bool_permissive([0x00, 0x01, 0x02].as_ref()),
-               Err(Error {
-                   required: 1,
-                   actual: 3,
-                   reason: ErrorReason::InvalidValue,
-               }));
+               Err(Error::InvalidValue));
     assert_eq!(guarded_transmute_bool_permissive([0x05, 0x01, 0x00].as_ref()),
-               Err(Error {
-                   required: 1,
-                   actual: 3,
-                   reason: ErrorReason::InvalidValue,
-               }));
+               Err(Error::InvalidValue));
     assert_eq!(guarded_transmute_bool_permissive([0xFF].as_ref()),
-               Err(Error {
-                   required: 1,
-                   actual: 1,
-                   reason: ErrorReason::InvalidValue,
-               }));
+               Err(Error::InvalidValue));
 }

--- a/tests/guarded_transmute_bool_vec_pedantic/mod.rs
+++ b/tests/guarded_transmute_bool_vec_pedantic/mod.rs
@@ -1,14 +1,14 @@
-use safe_transmute::{ErrorReason, Error, guarded_transmute_bool_vec_pedantic};
+use safe_transmute::{ErrorReason, Error, GuardError, guarded_transmute_bool_vec_pedantic};
 
 
 #[test]
 fn too_short() {
     assert_eq!(guarded_transmute_bool_vec_pedantic(vec![]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 1,
                    actual: 0,
                    reason: ErrorReason::NotEnoughBytes,
-               }));
+               })));
 }
 
 #[test]
@@ -22,21 +22,9 @@ fn just_enough() {
 #[test]
 fn invalid_bytes() {
     assert_eq!(guarded_transmute_bool_vec_pedantic(vec![0x00, 0x01, 0x02]),
-               Err(Error {
-                   required: 1,
-                   actual: 3,
-                   reason: ErrorReason::InvalidValue,
-               }));
+               Err(Error::InvalidValue));
     assert_eq!(guarded_transmute_bool_vec_pedantic(vec![0x05, 0x01, 0x00]),
-               Err(Error {
-                   required: 1,
-                   actual: 3,
-                   reason: ErrorReason::InvalidValue,
-               }));
+               Err(Error::InvalidValue));
     assert_eq!(guarded_transmute_bool_vec_pedantic(vec![0xFF]),
-               Err(Error {
-                   required: 1,
-                   actual: 1,
-                   reason: ErrorReason::InvalidValue,
-               }));
+               Err(Error::InvalidValue));
 }

--- a/tests/guarded_transmute_bool_vec_permissive/mod.rs
+++ b/tests/guarded_transmute_bool_vec_permissive/mod.rs
@@ -1,4 +1,4 @@
-use safe_transmute::{ErrorReason, Error, guarded_transmute_bool_vec_permissive};
+use safe_transmute::{Error, guarded_transmute_bool_vec_permissive};
 
 
 #[test]
@@ -17,21 +17,9 @@ fn just_enough() {
 #[test]
 fn invalid_bytes() {
     assert_eq!(guarded_transmute_bool_vec_permissive(vec![0x00, 0x01, 0x02]),
-               Err(Error {
-                   required: 1,
-                   actual: 3,
-                   reason: ErrorReason::InvalidValue,
-               }));
+               Err(Error::InvalidValue));
     assert_eq!(guarded_transmute_bool_vec_permissive(vec![0x05, 0x01, 0x00]),
-               Err(Error {
-                   required: 1,
-                   actual: 3,
-                   reason: ErrorReason::InvalidValue,
-               }));
+               Err(Error::InvalidValue));
     assert_eq!(guarded_transmute_bool_vec_permissive(vec![0xFF]),
-               Err(Error {
-                   required: 1,
-                   actual: 1,
-                   reason: ErrorReason::InvalidValue,
-               }));
+               Err(Error::InvalidValue));
 }

--- a/tests/guarded_transmute_many/mod.rs
+++ b/tests/guarded_transmute_many/mod.rs
@@ -1,4 +1,4 @@
-use safe_transmute::{ErrorReason, Error, guarded_transmute_many};
+use safe_transmute::{ErrorReason, Error, GuardError, guarded_transmute_many};
 use self::super::LeToNative;
 
 
@@ -6,17 +6,17 @@ use self::super::LeToNative;
 fn too_short() {
     unsafe {
         assert_eq!(guarded_transmute_many::<u16>(&[]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 16 / 8,
                        actual: 0,
                        reason: ErrorReason::NotEnoughBytes,
-                   }));
+                   })));
         assert_eq!(guarded_transmute_many::<u16>(&[0x00]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 16 / 8,
                        actual: 1,
                        reason: ErrorReason::NotEnoughBytes,
-                   }));
+                   })));
     }
 }
 

--- a/tests/guarded_transmute_many_pedantic/mod.rs
+++ b/tests/guarded_transmute_many_pedantic/mod.rs
@@ -1,4 +1,4 @@
-use safe_transmute::{ErrorReason, Error, guarded_transmute_many_pedantic};
+use safe_transmute::{ErrorReason, Error, GuardError, guarded_transmute_many_pedantic};
 use self::super::LeToNative;
 
 
@@ -6,17 +6,17 @@ use self::super::LeToNative;
 fn too_short() {
     unsafe {
         assert_eq!(guarded_transmute_many_pedantic::<u16>(&[]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 16 / 8,
                        actual: 0,
                        reason: ErrorReason::NotEnoughBytes,
-                   }));
+                   })));
         assert_eq!(guarded_transmute_many_pedantic::<u16>(&[0x00]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 16 / 8,
                        actual: 1,
                        reason: ErrorReason::NotEnoughBytes,
-                   }));
+                   })));
     }
 }
 
@@ -34,16 +34,16 @@ fn just_enough() {
 fn too_much() {
     unsafe {
         assert_eq!(guarded_transmute_many_pedantic::<u16>(&[0x00, 0x01, 0x00]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 16 / 8,
                        actual: 3,
                        reason: ErrorReason::InexactByteCount,
-                   }));
+                   })));
         assert_eq!(guarded_transmute_many_pedantic::<u16>(&[0x00, 0x01, 0x00, 0x02, 0x00]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 16 / 8,
                        actual: 5,
                        reason: ErrorReason::InexactByteCount,
-                   }));
+                   })));
     }
 }

--- a/tests/guarded_transmute_pedantic/mod.rs
+++ b/tests/guarded_transmute_pedantic/mod.rs
@@ -1,4 +1,4 @@
-use safe_transmute::{ErrorReason, Error, guarded_transmute_pedantic};
+use safe_transmute::{ErrorReason, Error, GuardError, guarded_transmute_pedantic};
 use self::super::LeToNative;
 
 
@@ -6,17 +6,17 @@ use self::super::LeToNative;
 fn too_short() {
     unsafe {
         assert_eq!(guarded_transmute_pedantic::<u32>(&[]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 32 / 8,
                        actual: 0,
                        reason: ErrorReason::InexactByteCount,
-                   }));
+                   })));
         assert_eq!(guarded_transmute_pedantic::<u32>(&[0x00]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 32 / 8,
                        actual: 1,
                        reason: ErrorReason::InexactByteCount,
-                   }));
+                   })));
     }
 }
 
@@ -31,10 +31,10 @@ fn just_enough() {
 fn too_much() {
     unsafe {
         assert_eq!(guarded_transmute_pedantic::<u32>(&[0x00, 0x00, 0x00, 0x01, 0x00]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 32 / 8,
                        actual: 5,
                        reason: ErrorReason::InexactByteCount,
-                   }));
+                   })));
     }
 }

--- a/tests/guarded_transmute_pod/mod.rs
+++ b/tests/guarded_transmute_pod/mod.rs
@@ -1,21 +1,21 @@
-use safe_transmute::{ErrorReason, Error, guarded_transmute_pod};
+use safe_transmute::{ErrorReason, Error, GuardError, guarded_transmute_pod};
 use self::super::LeToNative;
 
 
 #[test]
 fn too_short() {
     assert_eq!(guarded_transmute_pod::<u32>(&[]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 32 / 8,
                    actual: 0,
                    reason: ErrorReason::NotEnoughBytes,
-               }));
+               })));
     assert_eq!(guarded_transmute_pod::<u32>(&[0x00]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 32 / 8,
                    actual: 1,
                    reason: ErrorReason::NotEnoughBytes,
-               }));
+               })));
 }
 
 #[test]

--- a/tests/guarded_transmute_pod_many/mod.rs
+++ b/tests/guarded_transmute_pod_many/mod.rs
@@ -1,21 +1,21 @@
-use safe_transmute::{ErrorReason, Error, guarded_transmute_pod_many};
+use safe_transmute::{ErrorReason, Error, GuardError, guarded_transmute_pod_many};
 use self::super::LeToNative;
 
 
 #[test]
 fn too_short() {
     assert_eq!(guarded_transmute_pod_many::<u16>(&[]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 16 / 8,
                    actual: 0,
                    reason: ErrorReason::NotEnoughBytes,
-               }));
+               })));
     assert_eq!(guarded_transmute_pod_many::<u16>(&[0x00]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 16 / 8,
                    actual: 1,
                    reason: ErrorReason::NotEnoughBytes,
-               }));
+               })));
 }
 
 #[test]

--- a/tests/guarded_transmute_pod_many_pedantic/mod.rs
+++ b/tests/guarded_transmute_pod_many_pedantic/mod.rs
@@ -1,21 +1,21 @@
-use safe_transmute::{ErrorReason, Error, guarded_transmute_pod_many_pedantic};
+use safe_transmute::{ErrorReason, Error, GuardError, guarded_transmute_pod_many_pedantic};
 use self::super::LeToNative;
 
 
 #[test]
 fn too_short() {
     assert_eq!(guarded_transmute_pod_many_pedantic::<u16>(&[]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 16 / 8,
                    actual: 0,
                    reason: ErrorReason::NotEnoughBytes,
-               }));
+               })));
     assert_eq!(guarded_transmute_pod_many_pedantic::<u16>(&[0x00]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 16 / 8,
                    actual: 1,
                    reason: ErrorReason::NotEnoughBytes,
-               }));
+               })));
 }
 
 #[test]
@@ -29,15 +29,15 @@ fn just_enough() {
 #[test]
 fn too_much() {
     assert_eq!(guarded_transmute_pod_many_pedantic::<u16>(&[0x00, 0x01, 0x00]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 16 / 8,
                    actual: 3,
                    reason: ErrorReason::InexactByteCount,
-               }));
+               })));
     assert_eq!(guarded_transmute_pod_many_pedantic::<u16>(&[0x00, 0x01, 0x00, 0x02, 0x00]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 16 / 8,
                    actual: 5,
                    reason: ErrorReason::InexactByteCount,
-               }));
+               })));
 }

--- a/tests/guarded_transmute_pod_pedantic/mod.rs
+++ b/tests/guarded_transmute_pod_pedantic/mod.rs
@@ -1,21 +1,21 @@
-use safe_transmute::{ErrorReason, Error, guarded_transmute_pod_pedantic};
+use safe_transmute::{ErrorReason, Error, GuardError, guarded_transmute_pod_pedantic};
 use self::super::LeToNative;
 
 
 #[test]
 fn too_short() {
     assert_eq!(guarded_transmute_pod_pedantic::<u32>(&[]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 32 / 8,
                    actual: 0,
                    reason: ErrorReason::InexactByteCount,
-               }));
+               })));
     assert_eq!(guarded_transmute_pod_pedantic::<u32>(&[0x00]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 32 / 8,
                    actual: 1,
                    reason: ErrorReason::InexactByteCount,
-               }));
+               })));
 }
 
 #[test]
@@ -27,9 +27,9 @@ fn just_enough() {
 #[test]
 fn too_much() {
     assert_eq!(guarded_transmute_pod_pedantic::<u32>(&[0x00, 0x00, 0x00, 0x01, 0x00]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 32 / 8,
                    actual: 5,
                    reason: ErrorReason::InexactByteCount,
-               }));
+               })));
 }

--- a/tests/guarded_transmute_pod_vec/mod.rs
+++ b/tests/guarded_transmute_pod_vec/mod.rs
@@ -1,21 +1,21 @@
-use safe_transmute::{ErrorReason, Error, guarded_transmute_pod_vec};
+use safe_transmute::{ErrorReason, Error, GuardError, guarded_transmute_pod_vec};
 use self::super::LeToNative;
 
 
 #[test]
 fn too_short() {
     assert_eq!(guarded_transmute_pod_vec::<u16>(vec![]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 16 / 8,
                    actual: 0,
                    reason: ErrorReason::NotEnoughBytes,
-               }));
+               })));
     assert_eq!(guarded_transmute_pod_vec::<u16>(vec![0x00]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 16 / 8,
                    actual: 1,
                    reason: ErrorReason::NotEnoughBytes,
-               }));
+               })));
 }
 
 #[test]

--- a/tests/guarded_transmute_pod_vec_pedantic/mod.rs
+++ b/tests/guarded_transmute_pod_vec_pedantic/mod.rs
@@ -1,21 +1,21 @@
-use safe_transmute::{ErrorReason, Error, guarded_transmute_pod_vec_pedantic};
+use safe_transmute::{ErrorReason, Error, GuardError, guarded_transmute_pod_vec_pedantic};
 use self::super::LeToNative;
 
 
 #[test]
 fn too_short() {
     assert_eq!(guarded_transmute_pod_vec_pedantic::<u16>(vec![]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 16 / 8,
                    actual: 0,
                    reason: ErrorReason::NotEnoughBytes,
-               }));
+               })));
     assert_eq!(guarded_transmute_pod_vec_pedantic::<u16>(vec![0x00]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 16 / 8,
                    actual: 1,
                    reason: ErrorReason::NotEnoughBytes,
-               }));
+               })));
 }
 
 #[test]
@@ -29,15 +29,15 @@ fn just_enough() {
 #[test]
 fn too_much() {
     assert_eq!(guarded_transmute_pod_vec_pedantic::<u16>(vec![0x00, 0x01, 0x00]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 16 / 8,
                    actual: 3,
                    reason: ErrorReason::InexactByteCount,
-               }));
+               })));
     assert_eq!(guarded_transmute_pod_vec_pedantic::<u16>(vec![0x00, 0x01, 0x00, 0x02, 0x00]),
-               Err(Error {
+               Err(Error::Guard(GuardError {
                    required: 16 / 8,
                    actual: 5,
                    reason: ErrorReason::InexactByteCount,
-               }));
+               })));
 }

--- a/tests/guarded_transmute_vec/mod.rs
+++ b/tests/guarded_transmute_vec/mod.rs
@@ -1,4 +1,4 @@
-use safe_transmute::{ErrorReason, Error, guarded_transmute_vec};
+use safe_transmute::{ErrorReason, Error, GuardError, guarded_transmute_vec};
 use self::super::LeToNative;
 
 
@@ -6,17 +6,17 @@ use self::super::LeToNative;
 fn too_short() {
     unsafe {
         assert_eq!(guarded_transmute_vec::<u16>(vec![]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 16 / 8,
                        actual: 0,
                        reason: ErrorReason::NotEnoughBytes,
-                   }));
+                   })));
         assert_eq!(guarded_transmute_vec::<u16>(vec![0x00]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 16 / 8,
                        actual: 1,
                        reason: ErrorReason::NotEnoughBytes,
-                   }));
+                   })));
     }
 }
 

--- a/tests/guarded_transmute_vec_pedantic/mod.rs
+++ b/tests/guarded_transmute_vec_pedantic/mod.rs
@@ -1,4 +1,4 @@
-use safe_transmute::{ErrorReason, Error, guarded_transmute_vec_pedantic};
+use safe_transmute::{ErrorReason, Error, GuardError, guarded_transmute_vec_pedantic};
 use self::super::LeToNative;
 
 
@@ -6,17 +6,17 @@ use self::super::LeToNative;
 fn too_short() {
     unsafe {
         assert_eq!(guarded_transmute_vec_pedantic::<u16>(vec![]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 16 / 8,
                        actual: 0,
                        reason: ErrorReason::NotEnoughBytes,
-                   }));
+                   })));
         assert_eq!(guarded_transmute_vec_pedantic::<u16>(vec![0x00]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 16 / 8,
                        actual: 1,
                        reason: ErrorReason::NotEnoughBytes,
-                   }));
+                   })));
     }
 }
 
@@ -34,16 +34,16 @@ fn just_enough() {
 fn too_much() {
     unsafe {
         assert_eq!(guarded_transmute_vec_pedantic::<u16>(vec![0x00, 0x01, 0x00]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 16 / 8,
                        actual: 3,
                        reason: ErrorReason::InexactByteCount,
-                   }));
+                   })));
         assert_eq!(guarded_transmute_vec_pedantic::<u16>(vec![0x00, 0x01, 0x00, 0x02, 0x00]),
-                   Err(Error {
+                   Err(Error::Guard(GuardError {
                        required: 16 / 8,
                        actual: 5,
                        reason: ErrorReason::InexactByteCount,
-                   }));
+                   })));
     }
 }


### PR DESCRIPTION
As part of #9 and previously mentioned in #11, this PR makes some changes to the crate's error types.

- make type `Error` an enum of all possible errors rather than an alias to `GuardError`.
- Make `InvalidData` a base variant rather than a guard error reason (since it's not related to the guard API).
- Add `Unaligned` as a future error variant.
- Improve some documentation in the Guard API

This is a breaking change that will be mostly noticeable to those manipulating these error values. All tests were adapted accordingly. It might be best to add alignment checks to the functions before the next release though (#22).