### PR TITLE
Adjust Travis CI to install Clippy properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,7 @@ script:
       cargo test --verbose;
     fi
   - if [ "$CLIPPY" ]; then
-      cargo install cargo-update;
-      cargo install-update -i cargo-update clippy;
+      cargo install -qf clippy &&
       cargo clippy;
     fi
   - if [ "$TRAVIS_TAG" ]; then cargo build --verbose --release; fi


### PR DESCRIPTION
In the latest Nightly toolchain builds, there was a chance that `cargo-update` was already cached, but Clippy needs to be reinstalled on every new toolchain.