### PR TITLE
Add badges to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,8 @@ exclude = ["*.enc"]
 
 [features]
 "test-unaligned" = []
+
+[badges]
+
+travis-ci = {repository = "nabijaczleweli/safe-transmute-rs", branch = "master"}
+appveyor = {repository = "nabijaczleweli/safe-transmute-rs", branch = "master"}


### PR DESCRIPTION
This makes Cargo and crates.io know about our pretty badges.