### PR TITLE
no_std support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ matrix:
       rust: stable
       services: docker
       sudo: required
+    - env: LANGUAGE=Rust CARGO_DEFAULT_FEATURES=--no-default-features
+      language: rust
+      rust: stable
 
   allow_failures:
     - rust: beta
@@ -37,9 +40,9 @@ before_script:
 script:
   - cargo build --verbose
   - if [ ! -z "$CROSS_TARGET" ]; then
-      cross test --verbose --target $CROSS_TARGET --features test-unaligned;
+      cross test --verbose --target $CROSS_TARGET $CARGO_DEFAULT_FEATURES --features test-unaligned;
     else
-      cargo test --verbose --features test-unaligned;
+      cargo test --verbose $CARGO_DEFAULT_FEATURES --features test-unaligned;
     fi
   - if [ "$CLIPPY" ]; then
       cargo install -f clippy;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://cdn.rawgit.com/nabijaczleweli/safe-transmute-rs/doc/saf
 repository = "https://github.com/nabijaczleweli/safe-transmute-rs"
 readme = "README.md"
 keywords = ["safe", "transmute", "checked"]
-categories = ["rust-patterns", "memory-management"]
+categories = ["rust-patterns", "memory-management", "no-std"]
 license = "MIT"
 # Remember to also update in appveyor.yml
 version = "0.9.0"
@@ -14,4 +14,6 @@ authors = ["nabijaczleweli <nabijaczleweli@gmail.com>",
 exclude = ["*.enc"]
 
 [features]
+default = ["std"]
+"std" = []
 "test-unaligned" = []

--- a/src/bool.rs
+++ b/src/bool.rs
@@ -4,8 +4,10 @@
 //! behind the `bool` value is neither one.
 
 
-use self::super::{Error, guarded_transmute_many_permissive, guarded_transmute_vec_permissive, guarded_transmute_many_pedantic, guarded_transmute_vec_pedantic};
-use std::mem::size_of;
+use self::super::{Error, guarded_transmute_many_permissive, guarded_transmute_many_pedantic};
+#[cfg(feature = "std")]
+use self::super::{guarded_transmute_vec_permissive, guarded_transmute_vec_pedantic};
+use core::mem::size_of;
 
 
 /// Makes sure that the bytes represent a sequence of valid boolean values. It is done
@@ -86,6 +88,7 @@ pub fn guarded_transmute_bool_pedantic(bytes: &[u8]) -> Result<&[bool], Error> {
 /// # }
 /// # run().unwrap()
 /// ```
+#[cfg(feature = "std")]
 pub fn guarded_transmute_bool_vec_permissive(bytes: Vec<u8>) -> Result<Vec<bool>, Error> {
     check_bool(&bytes)?;
     unsafe { Ok(guarded_transmute_vec_permissive(bytes)) }
@@ -111,6 +114,7 @@ pub fn guarded_transmute_bool_vec_permissive(bytes: Vec<u8>) -> Result<Vec<bool>
 /// # }
 /// # run().unwrap()
 /// ```
+#[cfg(feature = "std")]
 pub fn guarded_transmute_bool_vec_pedantic(bytes: Vec<u8>) -> Result<Vec<bool>, Error> {
     check_bool(&bytes)?;
     unsafe { guarded_transmute_vec_pedantic(bytes) }

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -61,7 +61,7 @@
 
 
 use error::{ErrorReason, GuardError};
-use std::mem::size_of;
+use core::mem::size_of;
 
 
 /// The trait describes types which define boundary checking strategies.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,13 +87,19 @@
 //! ```
 
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(feature = "std")]
+extern crate core;
+
 mod pod;
 mod bool;
 mod error;
 mod to_bytes;
 
-use std::slice;
-use std::mem::{size_of, forget};
+use core::slice;
+use core::mem::size_of;
+#[cfg(feature = "std")]
+use core::mem::forget;
 use guard::{SingleValueGuard, PermissiveGuard, SingleManyGuard, PedanticGuard, Guard};
 
 pub mod util;
@@ -101,11 +107,14 @@ pub mod guard;
 
 pub use self::error::{ErrorReason, GuardError, Error};
 pub use self::to_bytes::{guarded_transmute_to_bytes_pod_many, guarded_transmute_to_bytes_many, guarded_transmute_to_bytes_pod, guarded_transmute_to_bytes};
-pub use self::pod::{PodTransmutable, guarded_transmute_pod_many_permissive, guarded_transmute_pod_vec_permissive, guarded_transmute_pod_many_pedantic,
-                    guarded_transmute_pod_vec_pedantic, guarded_transmute_pod_pedantic, guarded_transmute_pod_many, guarded_transmute_pod_vec,
-                    guarded_transmute_pod};
-pub use self::bool::{guarded_transmute_bool_vec_permissive, guarded_transmute_bool_vec_pedantic, guarded_transmute_bool_permissive,
-                     guarded_transmute_bool_pedantic};
+pub use self::pod::{PodTransmutable, guarded_transmute_pod_many_permissive, guarded_transmute_pod_many_pedantic,
+                    guarded_transmute_pod_pedantic, guarded_transmute_pod_many, guarded_transmute_pod};
+#[cfg(feature = "std")]
+pub use self::pod::{guarded_transmute_pod_vec_permissive, guarded_transmute_pod_vec_pedantic, guarded_transmute_pod_vec};
+
+pub use self::bool::{guarded_transmute_bool_permissive, guarded_transmute_bool_pedantic};
+#[cfg(feature = "std")]
+pub use self::bool::{guarded_transmute_bool_vec_permissive, guarded_transmute_bool_vec_pedantic};
 
 
 /// Transmute a byte slice into a single instance of a `Copy`able type.
@@ -255,6 +264,7 @@ pub unsafe fn guarded_transmute_many_pedantic<T>(bytes: &[u8]) -> Result<&[T], E
 /// # }
 /// # }
 /// ```
+#[cfg(feature = "std")]
 pub unsafe fn guarded_transmute_vec<T>(bytes: Vec<u8>) -> Result<Vec<T>, Error> {
     SingleManyGuard::check::<T>(&bytes)?;
     Ok(guarded_transmute_vec_permissive(bytes))
@@ -288,6 +298,7 @@ pub unsafe fn guarded_transmute_vec<T>(bytes: Vec<u8>) -> Result<Vec<T>, Error> 
 /// # }
 /// # }
 /// ```
+#[cfg(feature = "std")]
 pub unsafe fn guarded_transmute_vec_permissive<T>(mut bytes: Vec<u8>) -> Vec<T> {
     PermissiveGuard::check::<T>(&bytes).unwrap();
     let ptr = bytes.as_mut_ptr();
@@ -320,6 +331,7 @@ pub unsafe fn guarded_transmute_vec_permissive<T>(mut bytes: Vec<u8>) -> Vec<T> 
 /// # }
 /// # }
 /// ```
+#[cfg(feature = "std")]
 pub unsafe fn guarded_transmute_vec_pedantic<T>(bytes: Vec<u8>) -> Result<Vec<T>, Error> {
     PedanticGuard::check::<T>(&bytes)?;
     Ok(guarded_transmute_vec_permissive(bytes))

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -1,6 +1,7 @@
-use self::super::{Error, guarded_transmute_many_permissive, guarded_transmute_vec_permissive, guarded_transmute_many_pedantic, guarded_transmute_vec_pedantic,
-                  guarded_transmute_pedantic, guarded_transmute_many, guarded_transmute_vec, guarded_transmute};
-
+use self::super::{Error, guarded_transmute_many_permissive, guarded_transmute_many_pedantic, 
+                  guarded_transmute_pedantic, guarded_transmute_many, guarded_transmute};
+#[cfg(feature = "std")]
+use self::super::{guarded_transmute_vec_permissive, guarded_transmute_vec_pedantic, guarded_transmute_vec};
 
 /// Type that can be non-`unsafe`ly transmuted into
 ///
@@ -205,6 +206,7 @@ pub fn guarded_transmute_pod_many_pedantic<T: PodTransmutable>(bytes: &[u8]) -> 
 /// assert!(guarded_transmute_pod_vec::<i16>(vec![0xED]).is_err());
 /// # }
 /// ```
+#[cfg(feature = "std")]
 pub fn guarded_transmute_pod_vec<T: PodTransmutable>(bytes: Vec<u8>) -> Result<Vec<T>, Error> {
     unsafe { guarded_transmute_vec(bytes) }
 }
@@ -235,6 +237,7 @@ pub fn guarded_transmute_pod_vec<T: PodTransmutable>(bytes: Vec<u8>) -> Result<V
 /// assert_eq!(guarded_transmute_pod_vec_permissive::<u16>(vec![0xED]), vec![]);
 /// # }
 /// ```
+#[cfg(feature = "std")]
 pub fn guarded_transmute_pod_vec_permissive<T: PodTransmutable>(bytes: Vec<u8>) -> Vec<T> {
     unsafe { guarded_transmute_vec_permissive(bytes) }
 }
@@ -261,6 +264,7 @@ pub fn guarded_transmute_pod_vec_permissive<T: PodTransmutable>(bytes: Vec<u8>) 
 ///           .is_err());
 /// # }
 /// ```
+#[cfg(feature = "std")]
 pub fn guarded_transmute_pod_vec_pedantic<T: PodTransmutable>(bytes: Vec<u8>) -> Result<Vec<T>, Error> {
     unsafe { guarded_transmute_vec_pedantic(bytes) }
 }

--- a/src/to_bytes.rs
+++ b/src/to_bytes.rs
@@ -2,8 +2,8 @@
 
 
 use self::super::PodTransmutable;
-use std::mem::size_of;
-use std::slice;
+use core::mem::size_of;
+use core::slice;
 
 
 /// Transmute a single instance of an arbitrary type into a slice of its bytes.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
 //! Module containing various utility functions.
 
 
-use std::mem::transmute;
+use core::mem::transmute;
 
 
 /// If the specified 32-bit float is a signaling NaN, make it a quiet NaN.

--- a/tests/guarded_transmute_bool_vec_pedantic/mod.rs
+++ b/tests/guarded_transmute_bool_vec_pedantic/mod.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "std")]
 use safe_transmute::{ErrorReason, GuardError, Error, guarded_transmute_bool_vec_pedantic};
 
 

--- a/tests/guarded_transmute_bool_vec_permissive/mod.rs
+++ b/tests/guarded_transmute_bool_vec_permissive/mod.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "std")]
 use safe_transmute::{Error, guarded_transmute_bool_vec_permissive};
 
 

--- a/tests/guarded_transmute_pod_vec/mod.rs
+++ b/tests/guarded_transmute_pod_vec/mod.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "std")]
 use safe_transmute::{ErrorReason, GuardError, Error, guarded_transmute_pod_vec};
 use self::super::LeToNative;
 

--- a/tests/guarded_transmute_pod_vec_pedantic/mod.rs
+++ b/tests/guarded_transmute_pod_vec_pedantic/mod.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "std")]
 use safe_transmute::{ErrorReason, GuardError, Error, guarded_transmute_pod_vec_pedantic};
 use self::super::LeToNative;
 

--- a/tests/guarded_transmute_pod_vec_permissive/mod.rs
+++ b/tests/guarded_transmute_pod_vec_permissive/mod.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "std")]
 use safe_transmute::guarded_transmute_pod_vec_permissive;
 use self::super::LeToNative;
 

--- a/tests/guarded_transmute_vec/mod.rs
+++ b/tests/guarded_transmute_vec/mod.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "std")]
 use safe_transmute::{ErrorReason, GuardError, Error, guarded_transmute_vec};
 use self::super::LeToNative;
 

--- a/tests/guarded_transmute_vec_pedantic/mod.rs
+++ b/tests/guarded_transmute_vec_pedantic/mod.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "std")]
 use safe_transmute::{ErrorReason, GuardError, Error, guarded_transmute_vec_pedantic};
 use self::super::LeToNative;
 

--- a/tests/guarded_transmute_vec_permissive/mod.rs
+++ b/tests/guarded_transmute_vec_permissive/mod.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "std")]
 use safe_transmute::guarded_transmute_vec_permissive;
 use self::super::LeToNative;
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,3 +1,7 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(feature = "std")]
+extern crate core;
+
 extern crate safe_transmute;
 
 

--- a/tests/test_util/le_to_native.rs
+++ b/tests/test_util/le_to_native.rs
@@ -1,5 +1,5 @@
 #[cfg(target_endian = "big")]
-use std::mem::size_of;
+use core::mem::size_of;
 
 
 /// Verify: http://play.integer32.com/?gist=4cd795d6f45898c876a754cd3f3c2aaa&version=stable
@@ -22,6 +22,7 @@ impl<'a> LeToNative for &'a mut [u8] {
     }
 }
 
+#[cfg(feature = "std")]
 impl LeToNative for Vec<u8> {
     #[cfg(target_endian = "little")]
     fn le_to_native<T: Sized>(self) -> Self {

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,5 +1,5 @@
 use safe_transmute::util;
-use std::{f32, f64};
+use core::{f32, f64};
 
 
 #[test]


### PR DESCRIPTION
`no_std`  :ok_hand: 

- add default "std" feature
- *vec* function variants only exist with stdlib
- update tests accordingly
- include crate in "no-std" category
- add Travis CI entry for no_std testing