### PR TITLE
So it seems that bool is sure to be 1 byte sized now...

### DIFF
--- a/src/bool.rs
+++ b/src/bool.rs
@@ -11,8 +11,14 @@ use core::mem::size_of;
 
 
 /// Makes sure that the bytes represent a sequence of valid boolean values.
+///
+/// # Panic
+///
+/// This shouldn't happen on all currently supported platforms, but the
+/// function panics if the size of `bool` is not 1. 
 #[inline]
 pub fn bytes_are_bool(v: &[u8]) -> bool {
+    // TODO make this a static assert once it's available
     assert_eq!(size_of::<bool>(), 1);
     v.iter().all(|&x| x <= 1)
 }


### PR DESCRIPTION
... so we can simplify the function `bytes_are_bool` for some extra efficiency.