### PR TITLE
Fix vec-to-vec conversion primitives

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,7 +314,7 @@ pub unsafe fn guarded_transmute_vec_permissive<T>(mut bytes: Vec<u8>) -> Vec<T> 
     let capacity = bytes.capacity() / size_of::<T>();
     let len = bytes.len() / size_of::<T>();
     forget(bytes);
-    Vec::from_raw_parts(ptr as *mut T, capacity, len)
+    Vec::from_raw_parts(ptr as *mut T, len, capacity)
 }
 
 /// Trasform a byte vector into a vector of an arbitrary type.

--- a/src/to_bytes.rs
+++ b/src/to_bytes.rs
@@ -231,7 +231,7 @@ pub unsafe fn guarded_transmute_to_bytes_vec<T>(mut from: Vec<T>) -> Vec<u8> {
     let len = from.len() * size_of::<T>();
     let ptr = from.as_mut_ptr();
     forget(from);
-    Vec::from_raw_parts(ptr as *mut u8, capacity, len)
+    Vec::from_raw_parts(ptr as *mut u8, len, capacity)
 }
 
 /// Transmute a vector of POD types into a vector of their bytes,


### PR DESCRIPTION
`guarded_transmute_vec` functions were using the wrong function parameter order for `Vec::from_raw_parts`. A critical bug, so I'd call for high priority on merging this.