### PR TITLE
Install Clippy via Rustup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
       cargo install cross --force;
     fi
   - if [ "$CLIPPY" ]; then
-      rustup component add clippy-preview;
+      CLIPPY_INSTALLED=0 && (rustup component add clippy-preview || cargo install --git https://github.com/rust-lang/rust-clippy clippy -f) && CLIPPY_INSTALLED=1;
     fi
 
 script:
@@ -47,7 +47,7 @@ script:
     else
       cargo test --verbose $CARGO_DEFAULT_FEATURES;
     fi
-  - if [ "$CLIPPY" ]; then
+  - if [ "$CLIPPY_INSTALLED" == 1 ]; then
       cargo clippy;
     fi
   - if [ "$TRAVIS_TAG" ]; then cargo build --verbose --release; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ before_script:
       rustup target add $CROSS_TARGET;
       cargo install cross --force;
     fi
+  - if [ "$CLIPPY" ]; then
+      rustup component add clippy-preview;
+    fi
 
 script:
   - cargo build --verbose
@@ -45,7 +48,6 @@ script:
       cargo test --verbose $CARGO_DEFAULT_FEATURES;
     fi
   - if [ "$CLIPPY" ]; then
-      cargo install -f clippy;
       cargo clippy;
     fi
   - if [ "$TRAVIS_TAG" ]; then cargo build --verbose --release; fi


### PR DESCRIPTION
This updates Travis to install Clippy through Rustup, as is the current standard.
It does not succeed at the moment because there is currently an infrastructure hiccup (rust-lang/rust#56667). No nightlies are being pushed and the latest one does not even provide `clippy-preview`. We'll just wait and see.