### PR TITLE
Clippy clean up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
       cargo install cross --force;
     fi
   - if [ "$CLIPPY" ]; then
-      rustup component add clippy-preview;
+      CLIPPY_INSTALLED=0 && (rustup component add clippy-preview || cargo install --git https://github.com/rust-lang/rust-clippy clippy -f) && CLIPPY_INSTALLED=1;
     fi
 
 script:
@@ -47,7 +47,7 @@ script:
     else
       cargo test --verbose $CARGO_DEFAULT_FEATURES;
     fi
-  - if [ "$CLIPPY" ]; then
+  - if [ "$CLIPPY_INSTALLED" == 1 ]; then
       cargo clippy;
     fi
   - if [ "$TRAVIS_TAG" ]; then cargo build --verbose --release; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ before_script:
       rustup target add $CROSS_TARGET;
       cargo install cross --force;
     fi
+  - if [ "$CLIPPY" ]; then
+      rustup component add clippy-preview;
+    fi
 
 script:
   - cargo build --verbose
@@ -45,7 +48,6 @@ script:
       cargo test --verbose $CARGO_DEFAULT_FEATURES;
     fi
   - if [ "$CLIPPY" ]; then
-      cargo install -f clippy;
       cargo clippy;
     fi
   - if [ "$TRAVIS_TAG" ]; then cargo build --verbose --release; fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,9 +136,9 @@ pub use self::bool::{guarded_transmute_bool_permissive, guarded_transmute_bool_p
 /// // Little-endian
 /// # unsafe {
 /// # /*
-/// assert_eq!(guarded_transmute::<u32>(&[0x00, 0x00, 0x00, 0x01])?, 0x01000000);
+/// assert_eq!(guarded_transmute::<u32>(&[0x00, 0x00, 0x00, 0x01])?, 0x0100_0000);
 /// # */
-/// # assert_eq!(guarded_transmute::<u32>(&[0x00, 0x00, 0x00, 0x01].le_to_native::<u32>()).unwrap(), 0x01000000);
+/// # assert_eq!(guarded_transmute::<u32>(&[0x00, 0x00, 0x00, 0x01].le_to_native::<u32>()).unwrap(), 0x0100_0000);
 /// # }
 /// # }
 /// ```
@@ -263,7 +263,7 @@ pub unsafe fn guarded_transmute_many_pedantic<T>(bytes: &[u8]) -> Result<&[T], E
 /// assert_eq!(guarded_transmute_vec::<u32>(vec![0x04, 0x00, 0x00, 0x00, 0xED])?,
 /// # */
 /// # assert_eq!(guarded_transmute_vec::<u32>(vec![0x04, 0x00, 0x00, 0x00, 0xED].le_to_native::<u32>()).unwrap(),
-///            vec![0x00000004]);
+///            vec![0x0000_0004]);
 ///
 /// assert!(guarded_transmute_vec::<i16>(vec![0xED]).is_err());
 /// # }
@@ -298,7 +298,7 @@ pub unsafe fn guarded_transmute_vec<T>(bytes: Vec<u8>) -> Result<Vec<T>, Error> 
 /// assert_eq!(guarded_transmute_vec_permissive::<u32>(vec![0x04, 0x00, 0x00, 0x00, 0xED]),
 /// # */
 /// # assert_eq!(guarded_transmute_vec_permissive::<u32>(vec![0x04, 0x00, 0x00, 0x00, 0xED].le_to_native::<u32>()),
-///            vec![0x00000004]);
+///            vec![0x0000_0004]);
 /// assert_eq!(guarded_transmute_vec_permissive::<u16>(vec![0xED]), vec![]);
 /// # }
 /// # }

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -109,9 +109,9 @@ unsafe impl<T: PodTransmutable> PodTransmutable for [T; 32] {}
 /// # fn main() {
 /// // Little-endian
 /// # /*
-/// assert_eq!(guarded_transmute_pod::<u32>(&[0x00, 0x00, 0x00, 0x01])?, 0x01000000);
+/// assert_eq!(guarded_transmute_pod::<u32>(&[0x00, 0x00, 0x00, 0x01])?, 0x0100_0000);
 /// # */
-/// # assert_eq!(guarded_transmute_pod::<u32>(&[0x00, 0x00, 0x00, 0x01].le_to_native::<u32>()).unwrap(), 0x01000000);
+/// # assert_eq!(guarded_transmute_pod::<u32>(&[0x00, 0x00, 0x00, 0x01].le_to_native::<u32>()).unwrap(), 0x0100_0000);
 /// # }
 /// ```
 pub fn guarded_transmute_pod<T: PodTransmutable>(bytes: &[u8]) -> Result<T, Error> {
@@ -265,7 +265,7 @@ pub fn guarded_transmute_pod_many_pedantic<T: PodTransmutable>(bytes: &[u8]) -> 
 /// assert_eq!(guarded_transmute_pod_vec::<u32>(vec![0x04, 0x00, 0x00, 0x00, 0xED])?,
 /// # */
 /// # assert_eq!(guarded_transmute_pod_vec::<u32>(vec![0x04, 0x00, 0x00, 0x00, 0xED].le_to_native::<u32>()).unwrap(),
-///            vec![0x00000004]);
+///            vec![0x0000_0004]);
 ///
 /// assert!(guarded_transmute_pod_vec::<i16>(vec![0xED]).is_err());
 /// # }
@@ -305,7 +305,7 @@ pub fn guarded_transmute_pod_vec<T: PodTransmutable>(bytes: Vec<u8>) -> Result<V
 /// assert_eq!(guarded_transmute_pod_vec_permissive::<u32>(vec![0x04, 0x00, 0x00, 0x00, 0xED]),
 /// # */
 /// # assert_eq!(guarded_transmute_pod_vec_permissive::<u32>(vec![0x04, 0x00, 0x00, 0x00, 0xED].le_to_native::<u32>()),
-///            Ok(vec![0x00000004]));
+///            Ok(vec![0x0000_0004]));
 /// assert_eq!(guarded_transmute_pod_vec_permissive::<u16>(vec![0xED]), Ok(vec![]));
 /// # }
 /// ```

--- a/src/to_bytes.rs
+++ b/src/to_bytes.rs
@@ -19,7 +19,7 @@ use core::slice;
 /// # include!("../tests/test_util/le_to_native.rs");
 /// # fn main() {
 /// # unsafe {
-/// assert_eq!(guarded_transmute_to_bytes(&0x01234567),
+/// assert_eq!(guarded_transmute_to_bytes(&0x0123_4567),
 /// # /*
 ///            &[0x67, 0x45, 0x23, 0x01]);
 /// # */
@@ -106,7 +106,7 @@ pub unsafe fn guarded_transmute_to_bytes_many<T>(from: &[T]) -> &[u8] {
 /// # use safe_transmute::guarded_transmute_to_bytes_pod;
 /// # include!("../tests/test_util/le_to_native.rs");
 /// # fn main() {
-/// assert_eq!(guarded_transmute_to_bytes_pod(&0x01234567),
+/// assert_eq!(guarded_transmute_to_bytes_pod(&0x0123_4567),
 /// # /*
 ///            &[0x67, 0x45, 0x23, 0x01]);
 /// # */

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,6 +6,9 @@ use super::Error;
 
 
 /// If the specified 32-bit float is a signaling NaN, make it a quiet NaN.
+/// 
+/// Based on an old version of
+/// [`f32::from_bits()`](https://github.com/rust-lang/rust/pull/39271/files#diff-f60977ab00fd9ea9ba7ac918e12a8f42R1279)
 pub fn designalise_f32(f: f32) -> f32 {
     const EXP_MASK: u32 = 0x7F80_0000;
     const QNAN_MASK: u32 = 0x0040_0000;
@@ -24,6 +27,9 @@ pub fn designalise_f32(f: f32) -> f32 {
 }
 
 /// If the specified 64-bit float is a signaling NaN, make it a quiet NaN.
+/// 
+/// Based on an old version of
+/// [`f64::from_bits()`](https://github.com/rust-lang/rust/pull/39271/files#diff-2ae382eb5bbc830a6b884b8a6ba5d95fR1171)
 pub fn designalise_f64(f: f64) -> f64 {
     const EXP_MASK: u64 = 0x7FF0_0000_0000_0000;
     const QNAN_MASK: u64 = 0x0001_0000_0000_0000;

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,12 +6,10 @@ use super::Error;
 
 
 /// If the specified 32-bit float is a signaling NaN, make it a quiet NaN.
-///
-/// Based on [`f32::from_bits()`](https://github.com/rust-lang/rust/pull/39271/files#diff-f60977ab00fd9ea9ba7ac918e12a8f42R1279)
 pub fn designalise_f32(f: f32) -> f32 {
-    const EXP_MASK: u32 = 0x7F800000;
-    const QNAN_MASK: u32 = 0x00400000;
-    const FRACT_MASK: u32 = 0x007FFFFF;
+    const EXP_MASK: u32 = 0x7F80_0000;
+    const QNAN_MASK: u32 = 0x0040_0000;
+    const FRACT_MASK: u32 = 0x007F_FFFF;
 
     let mut f: u32 = unsafe { transmute(f) };
 
@@ -22,16 +20,14 @@ pub fn designalise_f32(f: f32) -> f32 {
         f |= QNAN_MASK;
     }
 
-    unsafe { transmute(f) }
+    f32::from_bits(f)
 }
 
 /// If the specified 64-bit float is a signaling NaN, make it a quiet NaN.
-///
-/// Based on [`f64::from_bits()`](https://github.com/rust-lang/rust/pull/39271/files#diff-2ae382eb5bbc830a6b884b8a6ba5d95fR1171)
 pub fn designalise_f64(f: f64) -> f64 {
-    const EXP_MASK: u64 = 0x7FF0000000000000;
-    const QNAN_MASK: u64 = 0x0001000000000000;
-    const FRACT_MASK: u64 = 0x000FFFFFFFFFFFFF;
+    const EXP_MASK: u64 = 0x7FF0_0000_0000_0000;
+    const QNAN_MASK: u64 = 0x0001_0000_0000_0000;
+    const FRACT_MASK: u64 = 0x000F_FFFF_FFFF_FFFF;
 
     let mut f: u64 = unsafe { transmute(f) };
 
@@ -42,7 +38,7 @@ pub fn designalise_f64(f: f64) -> f64 {
         f |= QNAN_MASK;
     }
 
-    unsafe { transmute(f) }
+    f64::from_bits(f)
 }
 
 /// Check whether the given data slice of `T`s is properly aligned for reading

--- a/tests/alignment_check/mod.rs
+++ b/tests/alignment_check/mod.rs
@@ -11,7 +11,7 @@ fn unaligned_slicing_integers() {
     assert_eq!(guarded_transmute_pod_many::<u16>(&bytes[2..]), Ok(&words[1..]));
     assert_eq!(guarded_transmute_pod_many::<u16>(&bytes[3..]), Err(Error::Unaligned { offset: 1 }));
 
-    let words = [0x02EE01FF, 0x04CC03DD, 0x06AA05BB];
+    let words = [0x02EE_01FF, 0x04CC_03DD, 0x06AA_05BB];
     let bytes = guarded_transmute_to_bytes_pod_many(&words);
 
     assert_eq!(guarded_transmute_pod_many::<u32>(bytes), Ok(words.as_ref()));
@@ -21,7 +21,7 @@ fn unaligned_slicing_integers() {
     assert_eq!(guarded_transmute_pod_many::<u32>(&bytes[4..]), Ok(&words[1..]));
     assert_eq!(guarded_transmute_pod_many::<u32>(&bytes[5..]), Err(Error::Unaligned { offset: 3 }));
 
-    let words = [0x02EE01FF_04CC03DD];
+    let words = [0x02EE_01FF_04CC_03DD];
     let bytes = guarded_transmute_to_bytes_pod_many(&words);
     assert_eq!(guarded_transmute_pod_many::<u64>(bytes), Ok(words.as_ref()));
     for i in 1..8 {

--- a/tests/guarded_transmute/mod.rs
+++ b/tests/guarded_transmute/mod.rs
@@ -23,21 +23,21 @@ fn too_short() {
 #[test]
 fn just_enough() {
     unsafe {
-        assert_eq!(guarded_transmute::<u32>(&[0x00, 0x00, 0x00, 0x01].le_to_native::<u32>()), Ok(0x01000000));
+        assert_eq!(guarded_transmute::<u32>(&[0x00, 0x00, 0x00, 0x01].le_to_native::<u32>()), Ok(0x0100_0000));
     }
 }
 
 #[test]
 fn too_much() {
     unsafe {
-        assert_eq!(guarded_transmute::<u32>(&[0x00, 0x00, 0x00, 0x01, 0x00].le_to_native::<u32>()), Ok(0x01000000));
+        assert_eq!(guarded_transmute::<u32>(&[0x00, 0x00, 0x00, 0x01, 0x00].le_to_native::<u32>()), Ok(0x0100_0000));
         assert_eq!(guarded_transmute::<u32>(&[0x00, 0x00, 0x00, 0x01, 0x00, 0x00].le_to_native::<u32>()),
-                   Ok(0x01000000));
+                   Ok(0x0100_0000));
         assert_eq!(guarded_transmute::<u32>(&[0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00].le_to_native::<u32>()),
-                   Ok(0x01000000));
+                   Ok(0x0100_0000));
         assert_eq!(guarded_transmute::<u32>(&[0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00].le_to_native::<u32>()),
-                   Ok(0x01000000));
+                   Ok(0x0100_0000));
         assert_eq!(guarded_transmute::<u32>(&[0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00].le_to_native::<u32>()),
-                   Ok(0x01000000));
+                   Ok(0x0100_0000));
     }
 }

--- a/tests/guarded_transmute_pedantic/mod.rs
+++ b/tests/guarded_transmute_pedantic/mod.rs
@@ -24,7 +24,7 @@ fn too_short() {
 fn just_enough() {
     unsafe {
         assert_eq!(guarded_transmute_pedantic::<u32>(&[0x00, 0x00, 0x00, 0x01].le_to_native::<u32>()),
-                   Ok(0x01000000));
+                   Ok(0x0100_0000));
     }
 }
 

--- a/tests/guarded_transmute_pod/mod.rs
+++ b/tests/guarded_transmute_pod/mod.rs
@@ -27,9 +27,9 @@ fn just_enough() {
 fn too_much() {
     let words: &[u32] = &[0x0100_0000, 0, 0];
     let bytes = guarded_transmute_to_bytes_pod_many(words);
-    assert_eq!(guarded_transmute_pod::<u32>(&bytes[..5]), Ok(0x01000000));
-    assert_eq!(guarded_transmute_pod::<u32>(&bytes[..6]), Ok(0x01000000));
-    assert_eq!(guarded_transmute_pod::<u32>(&bytes[..7]), Ok(0x01000000));
-    assert_eq!(guarded_transmute_pod::<u32>(&bytes[..8]), Ok(0x01000000));
-    assert_eq!(guarded_transmute_pod::<u32>(&bytes[..9]), Ok(0x01000000));
+    assert_eq!(guarded_transmute_pod::<u32>(&bytes[..5]), Ok(0x0100_0000));
+    assert_eq!(guarded_transmute_pod::<u32>(&bytes[..6]), Ok(0x0100_0000));
+    assert_eq!(guarded_transmute_pod::<u32>(&bytes[..7]), Ok(0x0100_0000));
+    assert_eq!(guarded_transmute_pod::<u32>(&bytes[..8]), Ok(0x0100_0000));
+    assert_eq!(guarded_transmute_pod::<u32>(&bytes[..9]), Ok(0x0100_0000));
 }

--- a/tests/guarded_transmute_pod_many_pedantic/mod.rs
+++ b/tests/guarded_transmute_pod_many_pedantic/mod.rs
@@ -19,7 +19,7 @@ fn too_short() {
 
 #[test]
 fn just_enough() {
-    let words: &[u16] = &[0x01000, 0x02000];
+    let words: &[u16] = &[0x1000, 0x2000];
     let bytes = guarded_transmute_to_bytes_pod_many(words);
     assert_eq!(guarded_transmute_pod_many_pedantic::<u16>(&bytes[..2]), Ok(&words[..1]));
     assert_eq!(guarded_transmute_pod_many_pedantic::<u16>(bytes), Ok(words));
@@ -27,7 +27,7 @@ fn just_enough() {
 
 #[test]
 fn too_much() {
-    let words: &[u16] = &[0x01000, 0x02000, 0x0300];
+    let words: &[u16] = &[0x1000, 0x2000, 0x300];
     let bytes = guarded_transmute_to_bytes_pod_many(words);
     assert_eq!(guarded_transmute_pod_many_pedantic::<u16>(&bytes[..3]),
                Err(Error::Guard(GuardError {

--- a/tests/guarded_transmute_pod_pedantic/mod.rs
+++ b/tests/guarded_transmute_pod_pedantic/mod.rs
@@ -20,7 +20,7 @@ fn too_short() {
 #[test]
 fn just_enough() {
     assert_eq!(guarded_transmute_pod_pedantic::<u32>(&guarded_transmute_to_bytes_pod_many::<u32>(&[0x0100_0000])),
-               Ok(0x01000000));
+               Ok(0x0100_0000));
 }
 
 #[test]


### PR DESCRIPTION
With Clippy working, we can clear all the warnings with this.

- add separators to long integer literals (underscore separators are the new fashion)
- use from_bits in designalise functions (it does the same thing as transmute now, but this one is considered safe and less error-prone)