### PR TITLE
Make `bool` size check static

### DIFF
--- a/src/bool.rs
+++ b/src/bool.rs
@@ -3,22 +3,24 @@
 //! Transmuting to `bool` is not undefined behavior if the transmuted value is
 //! either 0 or 1. These functions will return an error if the integer value
 //! behind the `bool` value is neither one.
-
+//! 
+//! # Note
+//! 
+//! Currently, these functions only work on systems in which the size of `bool`
+//! is exactly 1 (which are all platforms supported by Rust at the time of
+//! writing). In the event that you find a platform with an unexpected `bool`
+//! size, please report at the project's
+//! [issue tracker](https://github.com/nabijaczleweli/safe-transmute-rs/issues/new).
 
 use self::super::guard::{PermissiveGuard, PedanticGuard, Guard};
 use self::super::base::guarded_transmute_many;
 #[cfg(feature = "std")]
 use self::super::base::guarded_transmute_vec;
-use core::mem::{transmute, size_of};
+use core::mem::transmute;
 use self::super::Error;
 
 
 /// Makes sure that the bytes represent a sequence of valid boolean values.
-///
-/// # Panics
-///
-/// This shouldn't happen on all currently supported platforms, but this
-/// function panics if the size of `bool` isn't 1.
 ///
 /// # Examples
 ///
@@ -30,12 +32,7 @@ use self::super::Error;
 /// ```
 #[inline]
 pub fn bytes_are_bool(v: &[u8]) -> bool {
-    // TODO make this a static assert once available
-    assert_eq!(size_of::<bool>(),
-               1,
-               "unsupported platform due to invalid bool size {}, please report over at https://github.com/nabijaczleweli/safe-transmute-rs/issues/new",
-               size_of::<bool>());
-
+    let _ = transmute::<bool, u8>;
     v.iter().cloned().all(byte_is_bool)
 }
 

--- a/src/bool.rs
+++ b/src/bool.rs
@@ -32,7 +32,7 @@ use self::super::Error;
 /// ```
 #[inline]
 pub fn bytes_are_bool(v: &[u8]) -> bool {
-    let _ = transmute::<bool, u8>;
+    let _bool_must_be_1_byte_pls_report = transmute::<bool, u8>;
     v.iter().cloned().all(byte_is_bool)
 }
 


### PR DESCRIPTION
We wanted it, we got it. The trick is to exploit `std::mem::transmute`'s exclusive compile-time check of its type parameters' sizes.

I also moved the docs mentioning the support for 1-byte bools to the root of the module.