### PR TITLE
UnalignedVecError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,10 @@
 //! Detectable and recoverable-from transmutation precondition errors.
 
-
+#[cfg(feature = "std")]
+use crate::PodTransmutable;
+use core::fmt;
 #[cfg(feature = "std")]
 use std::error::Error as StdError;
-use core::fmt;
-
 
 /// A transmutation error. This type describes possible errors originating
 /// from operations in this crate.
@@ -14,8 +14,7 @@ use core::fmt;
 /// ```
 /// # use safe_transmute::{ErrorReason, Error, transmute_bool_pedantic};
 /// # unsafe {
-/// assert_eq!(transmute_bool_pedantic(&[0x05]),
-///            Err(Error::InvalidValue));
+/// assert_eq!(transmute_bool_pedantic(&[0x05]), Err(Error::InvalidValue));
 /// # }
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -24,6 +23,10 @@ pub enum Error {
     Guard(GuardError),
     /// The given data slice is not properly aligned for the target type.
     Unaligned(UnalignedError),
+    /// The given data vector is not properly aligned for the target type.
+    /// Does not exist in `no_std`.
+    #[cfg(feature = "std")]
+    UnalignedVec(UnalignedVecError),
     /// The data contains an invalid value for the target type.
     InvalidValue,
 }
@@ -33,8 +36,9 @@ impl StdError for Error {
     fn description(&self) -> &str {
         match *self {
             Error::Guard(ref e) => e.description(),
-            Error::Unaligned { .. } => "Unaligned data slice",
-            Error::InvalidValue => "Invalid target value",
+            Error::Unaligned(ref e) => e.description(),
+            Error::UnalignedVec(ref e) => e.description(),
+            Error::InvalidValue => "invalid target value",
         }
     }
 }
@@ -44,6 +48,8 @@ impl fmt::Display for Error {
         match *self {
             Error::Guard(ref e) => e.fmt(f),
             Error::Unaligned(ref e) => e.fmt(f),
+            #[cfg(feature = "std")]
+            Error::UnalignedVec(ref e) => e.fmt(f),
             Error::InvalidValue => f.write_str("Invalid target value"),
         }
     }
@@ -61,8 +67,15 @@ impl From<UnalignedError> for Error {
     }
 }
 
+#[cfg(feature = "std")]
+impl From<UnalignedVecError> for Error {
+    fn from(o: UnalignedVecError) -> Error {
+        Error::UnalignedVec(o)
+    }
+}
 
-/// A slice boundary guard error, usually created by a [`Guard`](./guard/trait.Guard.html).
+/// A slice boundary guard error, usually created by a
+/// [`Guard`](./guard/trait.Guard.html).
 ///
 /// # Examples
 ///
@@ -70,12 +83,14 @@ impl From<UnalignedError> for Error {
 /// # use safe_transmute::{ErrorReason, GuardError};
 /// # use safe_transmute::guard::{Guard, SingleManyGuard};
 /// # unsafe {
-/// assert_eq!(SingleManyGuard::check::<u16>(&[0x00]),
-///            Err(GuardError {
-///                required: 16 / 8,
-///                actual: 1,
-///                reason: ErrorReason::NotEnoughBytes,
-///            }));
+/// assert_eq!(
+///     SingleManyGuard::check::<u16>(&[0x00]),
+///     Err(GuardError {
+///         required: 16 / 8,
+///         actual: 1,
+///         reason: ErrorReason::NotEnoughBytes,
+///     })
+/// );
 /// # }
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -88,7 +103,8 @@ pub struct GuardError {
     pub reason: ErrorReason,
 }
 
-/// How the type's size compares to the received byte count and the transmutation function's characteristic.
+/// How the type's size compares to the received byte count and the
+/// transmutation function's characteristic.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ErrorReason {
     /// Too few bytes to fill even one instance of a type.
@@ -100,7 +116,6 @@ pub enum ErrorReason {
     /// The byte amount received is not the same as the type's size.
     InexactByteCount,
 }
-
 
 #[cfg(feature = "std")]
 impl StdError for GuardError {
@@ -126,12 +141,11 @@ impl ErrorReason {
     }
 }
 
-
 /// Unaligned memory access error.
 ///
-/// Returned when the given data slice or vector is not properly aligned for the
-/// target type. It would have been properly aligned if `offset` bytes were
-/// shifted (discarded) from the front of the slice.
+/// Returned when the given data slice is not properly aligned for the target
+/// type. It would have been properly aligned if `offset` bytes were shifted
+/// (discarded) from the front of the slice.
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub struct UnalignedError {
     /// The required amount of bytes to discard at the front for the attempted
@@ -149,5 +163,75 @@ impl StdError for UnalignedError {
 impl fmt::Display for UnalignedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "data is unaligned (off by {} bytes)", self.offset)
+    }
+}
+
+#[cfg(feature = "std")]
+impl UnalignedError {
+    /// Add a vector of bytes to make this an error of type
+    /// `UnalignedVecError`.
+    pub fn with_vec(self, vec: Vec<u8>) -> UnalignedVecError {
+        UnalignedVecError {
+            offset: self.offset,
+            vec,
+        }
+    }
+}
+
+/// Unaligned vector translation error.
+///
+/// Returned when the given data vector is not properly aligned for the
+/// target type. It would have been properly aligned if `offset` bytes were
+/// shifted (discarded) from the front of the slice.
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+pub struct UnalignedVecError {
+    /// The required amount of bytes to discard at the front for the attempted
+    /// transmutation to be successful.
+    pub offset: usize,
+    /// The original vector.
+    pub vec: Vec<u8>,
+}
+
+#[cfg(feature = "std")]
+impl UnalignedVecError {
+    /// Create a copy of the data and transmute it. As the new vector will be
+    /// properly aligned for accessing values of type `T`, this operation will
+    /// never fail.
+    /// 
+    /// # Safety
+    /// 
+    /// The byte data in the vector needs to correspond to a valid contiguous
+    /// sequence of `T` values.
+    pub unsafe fn copy_unchecked<T>(&self) -> Vec<T> {
+        let len = self.vec.len() / core::mem::size_of::<T>();
+        let mut out = Vec::with_capacity(len);
+        out.set_len(len);
+        core::ptr::copy_nonoverlapping(self.vec.as_ptr() as *const u8, out.as_mut_ptr() as *mut u8, len * core::mem::size_of::<T>());
+        out
+    }
+
+    /// Create a copy of the data and transmute it. As `T` is safely
+    /// transmutable, and the new vector will be properly aligned for accessing
+    /// values of type `T`, this operation is safe and will never fail.
+    pub fn copy<T: PodTransmutable>(&self) -> Vec<T> {
+        unsafe {
+            // no value checks needed thanks to `PodTransmutable`
+            self.copy_unchecked::<T>()
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl StdError for UnalignedVecError {
+    fn description(&self) -> &str {
+        "vector is unaligned"
+    }
+}
+
+#[cfg(feature = "std")]
+impl fmt::Display for UnalignedVecError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "vector is unaligned (off by {} bytes)", self.offset)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,7 @@ pub enum Error {
     /// The given data slice is not properly aligned for the target type.
     Unaligned(UnalignedError),
     /// The given data vector is not properly aligned for the target type.
+    /// 
     /// Does not exist in `no_std`.
     #[cfg(feature = "std")]
     UnalignedVec(UnalignedVecError),
@@ -178,7 +179,7 @@ impl UnalignedError {
     }
 }
 
-/// Unaligned vector translation error.
+/// Unaligned vector transmutation error.
 ///
 /// Returned when the given data vector is not properly aligned for the
 /// target type. It would have been properly aligned if `offset` bytes were

--- a/src/full.rs
+++ b/src/full.rs
@@ -193,8 +193,11 @@ pub fn transmute_many_pedantic<T: PodTransmutable>(bytes: &[u8]) -> Result<&[T],
 /// ```
 #[cfg(feature = "std")]
 pub fn transmute_vec<T: PodTransmutable, G: Guard>(bytes: Vec<u8>) -> Result<Vec<T>, Error> {
-    check_alignment::<_, T>(&bytes)?;
-    unsafe { transmute_pod_vec::<T, G>(bytes) }
+    if let Err(e) = check_alignment::<_, T>(&bytes) {
+        Err(e.with_vec(bytes).into())
+    } else {
+        unsafe { transmute_pod_vec::<T, G>(bytes) }
+    }
 }
 
 /// Transform a byte vector into a vector of values.


### PR DESCRIPTION
- type for unaligned vectors with useful functions and access to the original byte vector (so that it is not lost)
- return this error variant instead of `UnalignedError` in `transmute_vec*`