### PR TITLE
Fix unaligned access in unsafe fn tests

### DIFF
--- a/tests/base_transmute_many_pedantic/mod.rs
+++ b/tests/base_transmute_many_pedantic/mod.rs
@@ -1,6 +1,5 @@
-use safe_transmute::{PedanticGuard, ErrorReason, GuardError, Error};
+use safe_transmute::{PedanticGuard, ErrorReason, GuardError, Error, transmute_to_bytes};
 use safe_transmute::base::transmute_many;
-use self::super::LeToNative;
 
 #[test]
 fn too_short() {
@@ -22,11 +21,15 @@ fn too_short() {
 
 #[test]
 fn just_enough() {
+
+    let words: &[u16] = &[0x0100, 0x0200, 0x0300];
+    let bytes = transmute_to_bytes(words);
+
     unsafe {
-        assert_eq!(transmute_many::<u16, PedanticGuard>(&[0x00, 0x01].le_to_native::<u16>()),
-                   Ok([0x0100u16].into_iter().as_slice()));
-        assert_eq!(transmute_many::<u16, PedanticGuard>(&[0x00, 0x01, 0x00, 0x02].le_to_native::<u16>()),
-                   Ok([0x0100u16, 0x0200u16].into_iter().as_slice()));
+        assert_eq!(transmute_many::<u16, PedanticGuard>(&bytes[..2]),
+                   Ok(&words[..1]));
+        assert_eq!(transmute_many::<u16, PedanticGuard>(bytes),
+                   Ok(words));
     }
 }
 

--- a/tests/base_transmute_many_permissive/mod.rs
+++ b/tests/base_transmute_many_permissive/mod.rs
@@ -4,29 +4,40 @@ use self::super::LeToNative;
 
 #[test]
 fn too_short() {
+    let words: &[u16] = &[0x0100, 0x0200, 0x0300];
+    let bytes = transmute_to_bytes(words);
+
     unsafe {
-        assert_eq!(transmute_many_permissive::<u16>(&[]), &[]);
-        assert_eq!(transmute_many_permissive::<u16>(&[0x00]), &[]);
+        assert_eq!(transmute_many::<u16, PermissiveGuard>(&[]), Ok(&[]));
+        assert_eq!(transmute_many::<u16, PermissiveGuard>(&bytes[..1]),
+                   Ok(words));
     }
 }
 
 #[test]
 fn just_enough() {
+    let words: &[u16] = &[0x0100, 0x0200, 0x0300];
+    let bytes = transmute_to_bytes(words);
+
     unsafe {
-        assert_eq!(transmute_many_permissive::<u16>(&[0x00, 0x01].le_to_native::<u16>()), &[0x0100u16]);
-        assert_eq!(transmute_many_permissive::<u16>(&[0x00, 0x01, 0x00, 0x02].le_to_native::<u16>()),
-                   &[0x0100u16, 0x0200u16]);
+        assert_eq!(transmute_many::<u16, PermissiveGuard>(&bytes[..2]),
+                   Ok(&words[..1]));
+        assert_eq!(transmute_many::<u16, PermissiveGuard>(bytes),
+                   Ok(words));
     }
 }
 
 #[test]
 fn too_much() {
+    let words: &[u16] = &[0x0100, 0x0200, 0x0300, 0];
+    let bytes = transmute_to_bytes(words);
+
     unsafe {
-        assert_eq!(transmute_many_permissive::<u16>(&[0x00, 0x01, 0x00].le_to_native::<u16>()),
-                   &[0x0100u16]);
-        assert_eq!(transmute_many_permissive::<u16>(&[0x00, 0x01, 0x00, 0x02, 0x00].le_to_native::<u16>()),
-                   &[0x0100u16, 0x0200u16]);
-        assert_eq!(transmute_many_permissive::<u16>(&[0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00].le_to_native::<u16>()),
-                   &[0x0100u16, 0x0200u16, 0x0300u16]);
+        assert_eq!(transmute_many::<u16, PermissiveGuard>(&bytes[..3]),
+                   Ok(&words[..1]));
+        assert_eq!(transmute_many::<u16, PermissiveGuard>(&bytes[..5]),
+                   Ok(&words[..2]));
+        assert_eq!(transmute_many::<u16, PermissiveGuard>(&bytes[..7]),
+                   Ok(&words[..3]));
     }
 }

--- a/tests/from_bytes/mod.rs
+++ b/tests/from_bytes/mod.rs
@@ -1,6 +1,5 @@
-use safe_transmute::{ErrorReason, GuardError, Error};
+use safe_transmute::{ErrorReason, GuardError, Error, transmute_to_bytes};
 use safe_transmute::base::from_bytes;
-use self::super::LeToNative;
 
 #[test]
 fn too_short() {
@@ -22,21 +21,23 @@ fn too_short() {
 
 #[test]
 fn just_enough() {
+    let word = [0x100_B0B0];
+    let bytes = transmute_to_bytes(&word[..]);
     unsafe {
-        assert_eq!(from_bytes::<u32>(&[0x00, 0x00, 0x00, 0x01].le_to_native::<u32>()), Ok(0x0100_0000));
+        assert_eq!(from_bytes::<u32>(bytes), Ok(0x0100_B0B0));
     }
 }
 
 #[test]
 fn too_much() {
+    let words = [0x100_C0C0, 0, 0, 0];
+    let bytes = transmute_to_bytes(&words[..]);
+    
     unsafe {
-        assert_eq!(from_bytes::<u32>(&[0x00, 0x00, 0x00, 0x01, 0x00].le_to_native::<u32>()), Ok(0x0100_0000));
-        assert_eq!(from_bytes::<u32>(&[0x00, 0x00, 0x00, 0x01, 0x00, 0x00].le_to_native::<u32>()), Ok(0x0100_0000));
-        assert_eq!(from_bytes::<u32>(&[0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00].le_to_native::<u32>()),
-                   Ok(0x0100_0000));
-        assert_eq!(from_bytes::<u32>(&[0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00].le_to_native::<u32>()),
-                   Ok(0x0100_0000));
-        assert_eq!(from_bytes::<u32>(&[0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00].le_to_native::<u32>()),
-                   Ok(0x0100_0000));
+        assert_eq!(from_bytes::<u32>(&bytes[..5]), Ok(0x100_C0C0));
+        assert_eq!(from_bytes::<u32>(&bytes[..6]), Ok(0x100_C0C0));
+        assert_eq!(from_bytes::<u32>(&bytes[..7]), Ok(0x100_C0C0));
+        assert_eq!(from_bytes::<u32>(&bytes[..8]), Ok(0x100_C0C0));
+        assert_eq!(from_bytes::<u32>(&bytes[..9]), Ok(0x100_C0C0));
     }
 }

--- a/tests/from_bytes_pedantic/mod.rs
+++ b/tests/from_bytes_pedantic/mod.rs
@@ -1,6 +1,5 @@
-use safe_transmute::{ErrorReason, GuardError, Error};
+use safe_transmute::{ErrorReason, GuardError, Error, transmute_to_bytes};
 use safe_transmute::base::from_bytes_pedantic;
-use self::super::LeToNative;
 
 
 #[test]
@@ -23,8 +22,10 @@ fn too_short() {
 
 #[test]
 fn just_enough() {
+    let word = [0x0100_0020];
+    let bytes = transmute_to_bytes(&word);
     unsafe {
-        assert_eq!(from_bytes_pedantic::<u32>(&[0x00, 0x00, 0x00, 0x01].le_to_native::<u32>()), Ok(0x0100_0000));
+        assert_eq!(from_bytes_pedantic::<u32>(bytes), Ok(0x0100_0020));
     }
 }
 

--- a/tests/test_util/aligned_vec.rs
+++ b/tests/test_util/aligned_vec.rs
@@ -12,7 +12,7 @@
 /// 
 /// # Safety
 /// 
-/// The resulting vector must then be dealloc'd with the function
+/// The resulting vector must then be deallocated with the function
 /// `dealloc_aligned_vec`, with exactly the same type parameter `T`.
 /// 
 /// **It is UB if the vector is modified, or not moved into
@@ -32,7 +32,7 @@ unsafe fn aligned_vec<T>(bytes: &[u8]) -> Vec<u8> {
 
     // the following code allocates a `Vec<T>` and turns it into
     // a `Vec<u8>`. Assuming that this vector will not be dropped
-    // in this state, reading bytes from vit is safe.
+    // in this state, reading bytes from it is safe.
     #[allow(unused_unsafe)]
     unsafe {
         let mut v: Vec<T> = Vec::with_capacity(capacity);

--- a/tests/test_util/aligned_vec.rs
+++ b/tests/test_util/aligned_vec.rs
@@ -1,8 +1,6 @@
 /// Create a new vector that contains the given bytes and is sure to have a
 /// memory alignment compatible with `T` at creation time.
 ///
-/// Do not modify the vector, or this assurance is gone.
-///
 /// # Examples
 ///
 /// ```
@@ -11,8 +9,17 @@
 /// // the vector's data is guaranteed to be aligned for access as a u32
 /// assert_eq!((vec.as_ptr() as usize) % align_of::<u32>(), 0);
 /// ```
+/// 
+/// # Safety
+/// 
+/// The resulting vector must then be dealloc'd with the function
+/// `dealloc_aligned_vec`, with exactly the same type parameter `T`.
+/// 
+/// **It is UB if the vector is modified, or not moved into
+/// `dealloc_aligned_vec`.**
+
 #[cfg(feature = "std")]
-fn aligned_vec<T>(bytes: &[u8]) -> Vec<u8> {
+unsafe fn aligned_vec<T>(bytes: &[u8]) -> Vec<u8> {
     use core::mem::{align_of, forget, size_of};
 
     let vec_len_offset = bytes.len() % size_of::<T>();
@@ -23,6 +30,10 @@ fn aligned_vec<T>(bytes: &[u8]) -> Vec<u8> {
         vec_len
     };
 
+    // the following code allocates a `Vec<T>` and turns it into
+    // a `Vec<u8>`. Assuming that this vector will not be dropped
+    // in this state, reading bytes from vit is safe.
+    #[allow(unused_unsafe)]
     unsafe {
         let mut v: Vec<T> = Vec::with_capacity(capacity);
         let ptr = v.as_mut_ptr() as *mut u8;
@@ -37,4 +48,16 @@ fn aligned_vec<T>(bytes: &[u8]) -> Vec<u8> {
 
         vec
     }
+}
+
+/// Deallocate a vector created by `aligned_vec`.
+///
+/// # Safety
+/// 
+/// Obviously, this should not be called on a vector which was not created by
+/// `aligned_vec`. The type parameter `T` must also match the one used to
+/// create the vector.
+#[cfg(feature = "std")]
+unsafe fn dealloc_aligned_vec<T>(vec: Vec<u8>) {
+    safe_transmute::base::transmute_vec::<_, T>(vec);
 }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -45,53 +45,24 @@ fn smoke_check_alignment_from_8() {
 }
 
 #[cfg(feature = "std")]
+fn check_aligned_vec_with<T>(bytes: &[u8]) {
+    unsafe {
+        let vec: Vec<u8> = aligned_vec::<T>(bytes);
+        assert_eq!((vec.as_ptr() as usize) % align_of::<T>(), 0);
+        assert_eq!(&*vec, bytes);
+        dealloc_aligned_vec::<T>(vec);
+    }
+}
+
+#[cfg(feature = "std")]
 #[test]
 fn test_aligned_vec() {
-    let data: &[u8] = &[0xFF, 0xFF, 0x03, 0x00];
-    unsafe {
-        let vec = aligned_vec::<u32>(data);
-        assert_eq!((vec.as_ptr() as usize) % align_of::<u32>(), 0);
-        dealloc_aligned_vec::<u32>(vec);
-    }
-
-    unsafe {
-        let vec = aligned_vec::<u16>(&[]);
-        assert_eq!(vec, vec![]);
-        dealloc_aligned_vec::<u16>(vec);
-    }
-    unsafe {
-        let vec = aligned_vec::<i32>(&[]);
-        assert_eq!(vec, vec![]);
-        dealloc_aligned_vec::<i32>(vec);
-    }
-
-    unsafe {
-        let vec = aligned_vec::<u64>(&[]);
-        assert_eq!(vec, vec![]);
-        dealloc_aligned_vec::<u64>(vec);
-    }
-
-    unsafe {
-        let vec = aligned_vec::<u64>(&[0]);
-        assert_eq!(vec, vec![0]);
-        dealloc_aligned_vec::<u64>(vec);
-    }
-
-    unsafe {
-        let vec = aligned_vec::<u32>(&[1, 2]);
-        assert_eq!(vec, vec![1, 2]);
-        dealloc_aligned_vec::<u32>(vec);
-    }
-
-    unsafe {
-        let vec = aligned_vec::<u64>(&[1, 2, 3]);
-        assert_eq!(vec, vec![1, 2, 3]);
-        dealloc_aligned_vec::<u64>(vec);
-    }
-
-    unsafe {
-        let vec = aligned_vec::<u64>(&[0xAA; 20]);
-        assert_eq!(vec, vec![0xAA; 20]);
-        dealloc_aligned_vec::<u64>(vec);
-    }
+    check_aligned_vec_with::<u32>(&[0xFF, 0xFF, 0x03, 0x00]);
+    check_aligned_vec_with::<u16>(&[]);
+    check_aligned_vec_with::<i32>(&[]);
+    check_aligned_vec_with::<u64>(&[]);
+    check_aligned_vec_with::<u64>(&[0]);
+    check_aligned_vec_with::<u32>(&[1, 2]);
+    check_aligned_vec_with::<u64>(&[1, 2, 3]);
+    check_aligned_vec_with::<u64>(&[0xAA; 20]);
 }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -2,7 +2,7 @@ use safe_transmute::align::check_alignment;
 use safe_transmute::util;
 use core::mem::align_of;
 #[cfg(feature = "std")]
-use super::aligned_vec;
+use super::{aligned_vec, dealloc_aligned_vec};
 use core::{f32, f64};
 
 
@@ -48,15 +48,50 @@ fn smoke_check_alignment_from_8() {
 #[test]
 fn test_aligned_vec() {
     let data: &[u8] = &[0xFF, 0xFF, 0x03, 0x00];
-    let vec = aligned_vec::<u32>(data);
-    assert_eq!((vec.as_ptr() as usize) % align_of::<u32>(), 0);
+    unsafe {
+        let vec = aligned_vec::<u32>(data);
+        assert_eq!((vec.as_ptr() as usize) % align_of::<u32>(), 0);
+        dealloc_aligned_vec::<u32>(vec);
+    }
 
-    assert_eq!(aligned_vec::<u16>([].as_ref()), vec![]);
-    assert_eq!(aligned_vec::<i32>([].as_ref()), vec![]);
-    assert_eq!(aligned_vec::<u64>([].as_ref()), vec![]);
+    unsafe {
+        let vec = aligned_vec::<u16>(&[]);
+        assert_eq!(vec, vec![]);
+        dealloc_aligned_vec::<u16>(vec);
+    }
+    unsafe {
+        let vec = aligned_vec::<i32>(&[]);
+        assert_eq!(vec, vec![]);
+        dealloc_aligned_vec::<i32>(vec);
+    }
 
-    assert_eq!(aligned_vec::<u64>([0].as_ref()), vec![0]);
-    assert_eq!(aligned_vec::<u32>([1, 2].as_ref()), vec![1, 2]);
-    assert_eq!(aligned_vec::<u64>([1, 2, 3].as_ref()), vec![1, 2, 3]);
-    assert_eq!(aligned_vec::<u64>([0xAA; 20].as_ref()), vec![0xAA; 20]);
+    unsafe {
+        let vec = aligned_vec::<u64>(&[]);
+        assert_eq!(vec, vec![]);
+        dealloc_aligned_vec::<u64>(vec);
+    }
+
+    unsafe {
+        let vec = aligned_vec::<u64>(&[0]);
+        assert_eq!(vec, vec![0]);
+        dealloc_aligned_vec::<u64>(vec);
+    }
+
+    unsafe {
+        let vec = aligned_vec::<u32>(&[1, 2]);
+        assert_eq!(vec, vec![1, 2]);
+        dealloc_aligned_vec::<u32>(vec);
+    }
+
+    unsafe {
+        let vec = aligned_vec::<u64>(&[1, 2, 3]);
+        assert_eq!(vec, vec![1, 2, 3]);
+        dealloc_aligned_vec::<u64>(vec);
+    }
+
+    unsafe {
+        let vec = aligned_vec::<u64>(&[0xAA; 20]);
+        assert_eq!(vec, vec![0xAA; 20]);
+        dealloc_aligned_vec::<u64>(vec);
+    }
 }


### PR DESCRIPTION
This should make the tests pass with Miri.