### PR TITLE
Make UnalignedError more useful

### DIFF
--- a/src/align.rs
+++ b/src/align.rs
@@ -12,14 +12,14 @@ use self::super::error::UnalignedError;
 ///
 /// An `Error::Unaligned` error is returned with the number of bytes to discard
 /// from the front in order to make the conversion safe from alignment concerns.
-pub fn check_alignment<S, T>(data: &[S]) -> Result<(), UnalignedError> {
+pub fn check_alignment<S, T>(data: &[S]) -> Result<(), UnalignedError<S, T>> {
     // TODO this could probably become more efficient once `ptr::align_offset`
     // is stabilized (#44488)
     let ptr = data.as_ptr();
     let offset = ptr as usize % align_of::<T>();
     if offset > 0 {
         // reverse the offset (from "bytes to insert" to "bytes to remove")
-        Err(UnalignedError { offset: size_of::<T>() - offset })
+        Err(UnalignedError::new(size_of::<T>() - offset, data))
     } else {
         Ok(())
     }

--- a/src/bool.rs
+++ b/src/bool.rs
@@ -50,7 +50,7 @@ fn transmute_bool<G: Guard>(bytes: &[u8]) -> Result<&[bool], Error<u8, bool>> {
 
 /// Helper function for returning an error if any of the bytes does not make a
 /// valid `bool`.
-fn check_bool<T>(bytes: &[u8]) -> Result<(), Error<u8, T>> {
+fn check_bool<'a, T>(bytes: &[u8]) -> Result<(), Error<'a, u8, T>> {
     if bytes_are_bool(bytes) {
         Ok(())
     } else {
@@ -67,7 +67,7 @@ fn check_bool<T>(bytes: &[u8]) -> Result<(), Error<u8, T>> {
 ///
 /// ```
 /// # use safe_transmute::{Error, transmute_bool_permissive};
-/// # fn run() -> Result<(), Error<u8, bool>> {
+/// # fn run() -> Result<(), Error<'static, u8, bool>> {
 /// assert_eq!(transmute_bool_permissive(&[0x00, 0x01, 0x00, 0x01])?,
 ///            &[false, true, false, true]);
 /// assert_eq!(transmute_bool_permissive(&[])?, &[]);
@@ -87,7 +87,7 @@ pub fn transmute_bool_permissive(bytes: &[u8]) -> Result<&[bool], Error<u8, bool
 ///
 /// ```
 /// # use safe_transmute::{Error, transmute_bool_pedantic};
-/// # fn run() -> Result<(), Error<u8, bool>> {
+/// # fn run() -> Result<(), Error<'static, u8, bool>> {
 /// assert_eq!(transmute_bool_pedantic(&[0x01, 0x01, 0x01, 0x01])?,
 ///            &[true, true, true, true]);
 /// assert!(transmute_bool_pedantic(&[]).is_err());
@@ -107,7 +107,7 @@ pub fn transmute_bool_pedantic(bytes: &[u8]) -> Result<&[bool], Error<u8, bool>>
 ///
 /// ```
 /// # use safe_transmute::{Error, transmute_bool_vec_permissive};
-/// # fn run() -> Result<(), Error<u8, bool>> {
+/// # fn run() -> Result<(), Error<'static, u8, bool>> {
 /// assert_eq!(transmute_bool_vec_permissive(vec![0x00, 0x01, 0x00, 0x01])?,
 ///            vec![false, true, false, true]);
 /// assert_eq!(transmute_bool_vec_permissive(vec![0x01, 0x00, 0x00, 0x00, 0x01])?,
@@ -118,7 +118,7 @@ pub fn transmute_bool_pedantic(bytes: &[u8]) -> Result<&[bool], Error<u8, bool>>
 /// # run().unwrap()
 /// ```
 #[cfg(feature = "std")]
-pub fn transmute_bool_vec_permissive(bytes: Vec<u8>) -> Result<Vec<bool>, Error<u8, bool>> {
+pub fn transmute_bool_vec_permissive(bytes: Vec<u8>) -> Result<Vec<bool>, Error<'static, u8, bool>> {
     check_bool(&bytes)?;
     PermissiveGuard::check::<u8>(&bytes)?;
     // Alignment guarantees are ensured, and all values have been checked,
@@ -135,7 +135,7 @@ pub fn transmute_bool_vec_permissive(bytes: Vec<u8>) -> Result<Vec<bool>, Error<
 ///
 /// ```
 /// # use safe_transmute::{Error, transmute_bool_vec_pedantic};
-/// # fn run() -> Result<(), Error<u8, bool>> {
+/// # fn run() -> Result<(), Error<'static, u8, bool>> {
 /// assert_eq!(transmute_bool_vec_pedantic(vec![0x00, 0x01, 0x00, 0x01])?,
 ///            vec![false, true, false, true]);
 ///
@@ -147,7 +147,7 @@ pub fn transmute_bool_vec_permissive(bytes: Vec<u8>) -> Result<Vec<bool>, Error<
 /// # run().unwrap()
 /// ```
 #[cfg(feature = "std")]
-pub fn transmute_bool_vec_pedantic(bytes: Vec<u8>) -> Result<Vec<bool>, Error<u8, bool>> {
+pub fn transmute_bool_vec_pedantic(bytes: Vec<u8>) -> Result<Vec<bool>, Error<'static, u8, bool>> {
     check_bool(&bytes)?;
     PedanticGuard::check::<u8>(&bytes)?;
 

--- a/src/full.rs
+++ b/src/full.rs
@@ -191,7 +191,7 @@ pub fn transmute_many_pedantic<T: TriviallyTransmutable>(bytes: &[u8]) -> Result
 /// # run().unwrap();
 /// ```
 #[cfg(feature = "std")]
-pub fn transmute_vec<S: TriviallyTransmutable, T: TriviallyTransmutable>(mut vec: Vec<S>) -> Result<Vec<T>, Error<S, T>> {
+pub fn transmute_vec<S: TriviallyTransmutable, T: TriviallyTransmutable>(mut vec: Vec<S>) -> Result<Vec<T>, Error<'static, S, T>> {
     if align_of::<S>() != align_of::<T>() || size_of::<S>() != size_of::<T>() {
         return Err(IncompatibleVecTargetError::new(vec).into());
     }

--- a/src/to_bytes.rs
+++ b/src/to_bytes.rs
@@ -208,6 +208,6 @@ pub fn guarded_transmute_to_bytes_pod_many<S: TriviallyTransmutable>(from: &[S])
 /// view of the vector or make a copy anyway.
 ///
 #[cfg(feature = "std")]
-pub fn transmute_to_bytes_vec<S: TriviallyTransmutable>(from: Vec<S>) -> Result<Vec<u8>, Error<S, u8>> {
+pub fn transmute_to_bytes_vec<S: TriviallyTransmutable>(from: Vec<S>) -> Result<Vec<u8>, Error<'static, S, u8>> {
     super::full::transmute_vec::<S, u8>(from)
 }

--- a/tests/alignment_check/mod.rs
+++ b/tests/alignment_check/mod.rs
@@ -9,30 +9,49 @@ fn unaligned_slicing_integers() {
 
     assert_eq!(transmute_many_permissive::<u16>(bytes), Ok(words.as_ref()));
     assert_eq!(transmute_many_permissive::<u16>(&bytes[1..]),
-               Err(Error::Unaligned(UnalignedError { offset: 1 })));
+               Err(Error::Unaligned(UnalignedError::new(1, &bytes[1..]))));
     assert_eq!(transmute_many_permissive::<u16>(&bytes[2..]), Ok(&words[1..]));
     assert_eq!(transmute_many_permissive::<u16>(&bytes[3..]),
-               Err(Error::Unaligned(UnalignedError { offset: 1 })));
+               Err(Error::Unaligned(UnalignedError::new(1, &bytes[3..]))));
 
     let words = [0x02EE_01FF, 0x04CC_03DD, 0x06AA_05BB];
     let bytes = transmute_to_bytes(&words);
 
     assert_eq!(transmute_many_permissive::<u32>(bytes), Ok(words.as_ref()));
     assert_eq!(transmute_many_permissive::<u32>(&bytes[1..]),
-               Err(Error::Unaligned(UnalignedError { offset: 3 })));
+               Err(Error::Unaligned(UnalignedError::new(3, &bytes[1..]))));
     assert_eq!(transmute_many_permissive::<u32>(&bytes[2..]),
-               Err(Error::Unaligned(UnalignedError { offset: 2 })));
+               Err(Error::Unaligned(UnalignedError::new(2, &bytes[2..]))));
     assert_eq!(transmute_many_permissive::<u32>(&bytes[3..]),
-               Err(Error::Unaligned(UnalignedError { offset: 1 })));
+               Err(Error::Unaligned(UnalignedError::new(1, &bytes[3..]))));
     assert_eq!(transmute_many_permissive::<u32>(&bytes[4..]), Ok(&words[1..]));
     assert_eq!(transmute_many_permissive::<u32>(&bytes[5..]),
-               Err(Error::Unaligned(UnalignedError { offset: 3 })));
+               Err(Error::Unaligned(UnalignedError::new(3, &bytes[5..]))));
 
-    let words = [0x02EE_01FF_04CC_03DD];
+    let words = [0x02EE_01FF_04CC_03DD, 0x06EE_05FF_08CC_07DD];
     let bytes = transmute_to_bytes(&words);
-    assert_eq!(transmute_many_permissive::<u64>(bytes), Ok(words.as_ref()));
+    assert_eq!(transmute_many_permissive::<u64>(bytes), Ok(&words[..]));
+    assert_eq!(transmute_many_permissive::<u64>(&bytes[8..]), Ok(&words[1..]));
     for i in 1..8 {
-        assert_eq!(transmute_many_permissive::<u64>(&bytes[i..]),
-                   Err(Error::Unaligned(UnalignedError { offset: 8 - i })));
+        let outcome = transmute_many_permissive::<u64>(&bytes[i..]);
+        assert_eq!(outcome, Err(Error::Unaligned(UnalignedError::new(8 - i, &bytes[i..]))));
+        #[cfg(feature = "std")]
+        {
+            let copied_data: Vec<_> = match outcome {
+                Ok(_) => unreachable!(),
+                Err(Error::Unaligned(e)) => e.copy(),
+                Err(e) => panic!("Expected `UnalignedError`, got {}", e),
+            };
+            assert_eq!(copied_data.len(), 1);
+            let number = u64::from(bytes[i])
+                + (u64::from(bytes[i + 1]) << 8)
+                + (u64::from(bytes[i + 2]) << 16)
+                + (u64::from(bytes[i + 3]) << 24)
+                + (u64::from(bytes[i + 4]) << 32)
+                + (u64::from(bytes[i + 5]) << 40)
+                + (u64::from(bytes[i + 6]) << 48)
+                + (u64::from(bytes[i + 7]) << 56);
+            assert_eq!(u64::to_le(copied_data[0]), number);
+        }
     }
 }


### PR DESCRIPTION
- retain source slice in some functions
- add lifetime parameter to `Error` for source data's lifetime
- add utility methods for transmute-copying into a vector
- `Error::None` is no longer needed too!