### PR TITLE
Fix documentation on slice guards

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -111,8 +111,8 @@ pub unsafe fn from_bytes_pedantic<T: Copy>(bytes: &[u8]) -> Result<T, Error<u8, 
 ///
 /// # Errors
 ///
-/// An error is returned if the slice does not have enough bytes for a single
-/// value `T`.
+/// An error is returned if the data does not comply with the policies of the
+/// given guard `G`.
 ///
 /// # Examples
 ///

--- a/src/full.rs
+++ b/src/full.rs
@@ -92,7 +92,7 @@ pub fn transmute_one_pedantic<T: TriviallyTransmutable>(bytes: &[u8]) -> Result<
 ///
 /// - The data does not have a memory alignment compatible with `T`. You will
 ///   have to make a copy anyway, or modify how the data was originally made.
-/// - The data does not have enough bytes for a single value `T`.
+/// - The data does not comply with the policies of the given guard `G`.
 ///
 /// # Examples
 ///

--- a/src/trivial.rs
+++ b/src/trivial.rs
@@ -183,9 +183,8 @@ pub unsafe fn transmute_trivial_pedantic<T: TriviallyTransmutable>(bytes: &[u8])
 ///
 /// # Errors
 ///
-/// An error is returned in one of the following situations:
-///
-/// - The data does not have enough bytes for a single value `T`.
+/// An error is returned if the data does not comply with the policies of the
+/// given guard `G`.
 ///
 /// # Safety
 ///


### PR DESCRIPTION
Some functions were specifying the behavior of a specific guard, but it's actually generic wrt to `G`. Probably something I overlooked last time I worked on that huge refactor.