### PR TITLE
_mut functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ pub mod trivial;
 pub mod util;
 pub mod to_bytes;
 
-pub use self::full::{transmute_many_permissive, transmute_many_pedantic, transmute_one_pedantic, transmute_many, transmute_one};
+pub use self::full::{transmute_many_permissive, transmute_many_permissive_mut, transmute_many_pedantic, transmute_many_pedantic_mut, transmute_one_pedantic, transmute_many, transmute_many_mut, transmute_one};
 #[cfg(feature = "std")]
 pub use self::full::transmute_vec;
 
@@ -171,7 +171,7 @@ pub use self::error::{UnalignedError, ErrorReason, GuardError, Error};
 pub use self::error::IncompatibleVecTargetError;
 pub use self::trivial::TriviallyTransmutable;
 
-pub use self::to_bytes::{transmute_one_to_bytes, transmute_to_bytes};
+pub use self::to_bytes::{transmute_one_to_bytes, transmute_one_to_bytes_mut, transmute_to_bytes, transmute_to_bytes_mut};
 #[cfg(feature = "std")]
 pub use self::to_bytes::transmute_to_bytes_vec;
 

--- a/src/to_bytes.rs
+++ b/src/to_bytes.rs
@@ -50,6 +50,55 @@ pub unsafe fn transmute_to_bytes_unchecked<S>(from: &S) -> &[u8] {
     slice::from_raw_parts(from as *const S as *const u8, size_of::<S>())
 }
 
+/// Transmute a single mutable instance of an arbitrary type into a mutable
+/// slice of its bytes.
+///
+/// # Safety
+/// 
+/// This function is very ill advised, since it can be exploited to break
+/// invariants of the source type. Any modification that leaves the data
+/// in an inconsistent state with respect to `S` is undefined behavior.
+///
+/// # Examples
+///
+/// An `u32`:
+///
+/// ```
+/// # use safe_transmute::to_bytes::transmute_to_bytes_unchecked_mut;
+/// # include!("../tests/test_util/le_to_native.rs");
+/// # fn main() {
+/// unsafe {
+///     assert_eq!(transmute_to_bytes_unchecked_mut(&mut 0x0123_4567),
+/// # /*
+///                &mut [0x67, 0x45, 0x23, 0x01]);
+/// # */
+/// #              &mut [0x67, 0x45, 0x23, 0x01].le_to_native::<u32>());
+/// }
+/// # }
+/// ```
+///
+/// An arbitrary type:
+///
+/// ```
+/// # use safe_transmute::to_bytes::transmute_to_bytes_unchecked_mut;
+/// #[repr(C)]
+/// struct Gene {
+///     x1: u8,
+///     x2: u8,
+/// }
+///
+/// unsafe {
+///     assert_eq!(transmute_to_bytes_unchecked_mut(&mut Gene {
+///                    x1: 0x42,
+///                    x2: 0x69,
+///                }),
+///                &mut [0x42, 0x69]);
+/// }
+/// ```
+pub unsafe fn transmute_to_bytes_unchecked_mut<S>(from: &mut S) -> &mut [u8] {
+    slice::from_raw_parts_mut(from as *mut S as *mut u8, size_of::<S>())
+}
+
 /// Transmute a slice of arbitrary types into a slice of their bytes.
 ///
 /// # Examples
@@ -96,6 +145,59 @@ pub unsafe fn transmute_to_bytes_many_unchecked<S>(from: &[S]) -> &[u8] {
     slice::from_raw_parts(from.as_ptr() as *const u8, from.len() * size_of::<S>())
 }
 
+/// Transmute a mutable slice of arbitrary types into a mutable slice of their
+/// bytes.
+/// 
+/// # Safety
+/// 
+/// This function is very ill advised, since it can be exploited to break
+/// invariants of the source type. Any modification that leaves the data
+/// in an inconsistent state with respect to `S` is undefined behavior.
+///
+/// # Examples
+///
+/// Some `u16`s:
+///
+/// ```
+/// # use safe_transmute::to_bytes::transmute_to_bytes_mut;
+/// # include!("../tests/test_util/le_to_native.rs");
+/// # fn main() {
+/// unsafe {
+///     assert_eq!(transmute_to_bytes_mut(&mut [0x0123u16, 0x4567u16]),
+/// # /*
+///                &[0x23, 0x01, 0x67, 0x45]);
+/// # */
+/// #               [0x23, 0x01, 0x67, 0x45].le_to_native::<u16>());
+/// }
+/// # }
+/// ```
+///
+/// An arbitrary type:
+///
+/// ```
+/// # use safe_transmute::to_bytes::transmute_to_bytes_many_unchecked;
+/// #[repr(C)]
+/// struct Gene {
+///     x1: u8,
+///     x2: u8,
+/// }
+///
+/// unsafe {
+///     assert_eq!(transmute_to_bytes_many_unchecked(&mut [Gene {
+///                                                        x1: 0x42,
+///                                                        x2: 0x69,
+///                                                    },
+///                                                    Gene {
+///                                                        x1: 0x12,
+///                                                        x2: 0x48,
+///                                                    }]),
+///                &[0x42, 0x69, 0x12, 0x48]);
+/// }
+/// ```
+pub unsafe fn transmute_to_bytes_many_unchecked_mut<S>(from: &mut [S]) -> &mut [u8] {
+    slice::from_raw_parts_mut(from.as_mut_ptr() as *mut u8, from.len() * size_of::<S>())
+}
+
 /// Transmute a single instance of a trivially transmutable type into a slice
 /// of its bytes.
 ///
@@ -135,6 +237,47 @@ pub unsafe fn transmute_to_bytes_many_unchecked<S>(from: &[S]) -> &[u8] {
 /// ```
 pub fn transmute_one_to_bytes<S: TriviallyTransmutable>(from: &S) -> &[u8] {
     unsafe { transmute_to_bytes_unchecked(from) }
+}
+
+/// Transmute a single instance of a trivially transmutable type into a slice
+/// of its bytes.
+///
+/// # Examples
+///
+/// An `u32`:
+///
+/// ```
+/// # use safe_transmute::transmute_one_to_bytes_mut;
+/// # include!("../tests/test_util/le_to_native.rs");
+/// # fn main() {
+/// assert_eq!(transmute_one_to_bytes_mut(&mut 0x0123_4567),
+/// # /*
+///            &mut [0x67, 0x45, 0x23, 0x01]);
+/// # */
+/// #          &mut [0x67, 0x45, 0x23, 0x01].le_to_native::<u32>());
+/// # }
+/// ```
+///
+/// An arbitrary type:
+///
+/// ```
+/// # use safe_transmute::{TriviallyTransmutable, transmute_one_to_bytes_mut};
+/// #[repr(C)]
+/// #[derive(Clone, Copy)]
+/// struct Gene {
+///     x1: u8,
+///     x2: u8,
+/// }
+/// unsafe impl TriviallyTransmutable for Gene {}
+///
+/// assert_eq!(transmute_one_to_bytes_mut(&mut Gene {
+///                x1: 0x42,
+///                x2: 0x69,
+///            }),
+///            &mut [0x42, 0x69]);
+/// ```
+pub fn transmute_one_to_bytes_mut<S: TriviallyTransmutable>(from: &mut S) -> &mut [u8] {
+    unsafe { transmute_to_bytes_unchecked_mut(from) }
 }
 
 /// Transmute a slice of arbitrary types into a slice of their bytes.
@@ -179,6 +322,51 @@ pub fn transmute_one_to_bytes<S: TriviallyTransmutable>(from: &S) -> &[u8] {
 /// ```
 pub fn transmute_to_bytes<S: TriviallyTransmutable>(from: &[S]) -> &[u8] {
     unsafe { transmute_to_bytes_many_unchecked(from) }
+}
+
+/// Transmute a mutable slice of a trivially transmutable type into a mutable
+/// slice of its bytes.
+///
+/// # Examples
+///
+/// Some `u16`s:
+///
+/// ```
+/// # use safe_transmute::transmute_to_bytes_mut;
+/// # include!("../tests/test_util/le_to_native.rs");
+/// # fn main() {
+/// assert_eq!(transmute_to_bytes_mut(&mut [0x0123u16, 0x4567u16]),
+/// # /*
+///            &mut [0x23, 0x01, 0x67, 0x45]);
+/// # */
+/// #          &mut [0x23, 0x01, 0x67, 0x45].le_to_native::<u16>());
+/// # }
+/// ```
+///
+/// An arbitrary type:
+///
+/// ```
+/// # use safe_transmute::{TriviallyTransmutable, transmute_to_bytes_mut};
+/// #[repr(C)]
+/// #[derive(Clone, Copy)]
+/// struct Gene {
+///     x1: u8,
+///     x2: u8,
+/// }
+/// unsafe impl TriviallyTransmutable for Gene {}
+///
+/// assert_eq!(transmute_to_bytes_mut(&mut [Gene {
+///                                             x1: 0x42,
+///                                             x2: 0x69,
+///                                         },
+///                                         Gene {
+///                                             x1: 0x12,
+///                                             x2: 0x48,
+///                                         }]),
+///            &mut [0x42, 0x69, 0x12, 0x48]);
+/// ```
+pub fn transmute_to_bytes_mut<S: TriviallyTransmutable>(from: &mut [S]) -> &mut [u8] {
+    unsafe { transmute_to_bytes_many_unchecked_mut(from) }
 }
 
 /// Transmute a slice of arbitrary types into a slice of their bytes.

--- a/src/to_bytes.rs
+++ b/src/to_bytes.rs
@@ -57,7 +57,7 @@ pub unsafe fn transmute_to_bytes_unchecked<S>(from: &S) -> &[u8] {
 /// 
 /// This function is very ill advised, since it can be exploited to break
 /// invariants of the source type. Any modification that leaves the data
-/// in an inconsistent state with respect to `S` is undefined behavior.
+/// in an inconsistent state with respect to `S` results in undefined behavior.
 ///
 /// # Examples
 ///

--- a/src/trivial.rs
+++ b/src/trivial.rs
@@ -16,7 +16,7 @@
 
 
 use self::super::guard::{PermissiveGuard, PedanticGuard, Guard};
-use self::super::base::{transmute_many, from_bytes};
+use self::super::base::{transmute_many, transmute_many_mut, from_bytes};
 #[cfg(feature = "std")]
 use self::super::base::transmute_vec;
 use self::super::Error;
@@ -211,6 +211,43 @@ pub unsafe fn transmute_trivial_pedantic<T: TriviallyTransmutable>(bytes: &[u8])
 /// ```
 pub unsafe fn transmute_trivial_many<T: TriviallyTransmutable, G: Guard>(bytes: &[u8]) -> Result<&[T], Error<u8, T>> {
     transmute_many::<T, G>(bytes)
+}
+
+/// Transmute a byte slice into a single instance of a trivially transmutable type.
+///
+/// The byte slice must have exactly enough bytes to fill a single instance of a type.
+///
+/// # Errors
+///
+/// An error is returned in one of the following situations:
+///
+/// - The data does not have enough bytes for a single value `T`.
+///
+/// # Safety
+///
+/// This function invokes undefined behavior if the data does not have a memory
+/// alignment compatible with `T`. If this cannot be ensured, you will have to
+/// make a copy of the data, or change how it was originally made.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use safe_transmute::trivial::transmute_trivial_many;
+/// # use safe_transmute::SingleManyGuard;
+/// # include!("../tests/test_util/le_to_native.rs");
+/// # fn main() {
+/// // Little-endian
+/// unsafe {
+/// # /*
+///     assert_eq!(transmute_trivial_many::<u16, SingleManyGuard>(&[0x00, 0x01, 0x00, 0x02])?,
+/// # */
+/// #   assert_eq!(transmute_trivial_many::<u16, SingleManyGuard>(&[0x00, 0x01, 0x00, 0x02].le_to_native::<u16>()).unwrap(),
+///                &[0x0100, 0x0200]);
+/// }
+/// # }
+/// ```
+pub unsafe fn transmute_trivial_many_mut<T: TriviallyTransmutable, G: Guard>(bytes: &mut [u8]) -> Result<&mut [T], Error<u8, T>> {
+    transmute_many_mut::<T, G>(bytes)
 }
 
 /// View a byte slice as a slice of a trivially transmutable type.

--- a/tests/base_transmute_many/mod.rs
+++ b/tests/base_transmute_many/mod.rs
@@ -1,5 +1,5 @@
-use safe_transmute::{SingleManyGuard, ErrorReason, GuardError, Error, transmute_to_bytes};
-use safe_transmute::base::transmute_many;
+use safe_transmute::{SingleManyGuard, ErrorReason, GuardError, Error, transmute_to_bytes, transmute_to_bytes_mut};
+use safe_transmute::base::{transmute_many, transmute_many_mut};
 
 #[test]
 fn too_short() {
@@ -44,5 +44,55 @@ fn too_much() {
                    Ok(&words[..2]));
         assert_eq!(transmute_many::<u16, SingleManyGuard>(&bytes[..7]),
                    Ok(&words[..3]));
+    }
+}
+
+#[test]
+fn too_short_mut() {
+    unsafe {
+        assert_eq!(transmute_many_mut::<u16, SingleManyGuard>(&mut []),
+                   Err(Error::Guard(GuardError {
+                       required: 16 / 8,
+                       actual: 0,
+                       reason: ErrorReason::NotEnoughBytes,
+                   })));
+        assert_eq!(transmute_many_mut::<u16, SingleManyGuard>(&mut [0x00]),
+                   Err(Error::Guard(GuardError {
+                       required: 16 / 8,
+                       actual: 1,
+                       reason: ErrorReason::NotEnoughBytes,
+                   })));
+    }
+}
+
+#[test]
+fn just_enough_mut() {
+    let words: &mut [u16] = &mut [0x0100, 0x0200, 0x0300];
+    let bytes = transmute_to_bytes_mut(words);
+    // make an independent version of `words` for eq testing
+    let words: &mut [u16] = &mut [0x0100, 0x0200, 0x0300];
+
+    unsafe {
+        assert_eq!(transmute_many_mut::<u16, SingleManyGuard>(&mut bytes[..2]),
+                   Ok(&mut words[..1]));
+        assert_eq!(transmute_many_mut::<u16, SingleManyGuard>(bytes),
+                   Ok(words));
+    }
+}
+
+#[test]
+fn too_much_mut() {
+    let words: &mut[u16] = &mut [0x0100, 0x0200, 0x0300, 0];
+    let bytes = transmute_to_bytes_mut(words);
+    // make an independent version of `words` for eq testing
+    let words: &mut [u16] = &mut [0x0100, 0x0200, 0x0300];
+
+    unsafe {
+        assert_eq!(transmute_many_mut::<u16, SingleManyGuard>(&mut bytes[..3]),
+                   Ok(&mut words[..1]));
+        assert_eq!(transmute_many_mut::<u16, SingleManyGuard>(&mut bytes[..5]),
+                   Ok(&mut words[..2]));
+        assert_eq!(transmute_many_mut::<u16, SingleManyGuard>(&mut bytes[..7]),
+                   Ok(&mut words[..3]));
     }
 }


### PR DESCRIPTION
This is a remake of the idea in #19, but written from scratch and already arranged according to the latest API structure.

- `base::transmute_many_mut()`
- `trivial::transmute_trivial_many_mut()`
- `to_bytes::{transmute_to_bytes_unchecked_mut,transmute_to_bytes_mut,
transmute_one_to_bytes_mut}()`
- `full::{transmute_many_mut, transmute_many_permissive_mut,
transmute_many_pedantic_mut}()`
- `align::check_alignment_mut()`