### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/tests/bool/pedantic.rs
+++ b/tests/bool/pedantic.rs
@@ -13,9 +13,9 @@ fn too_short() {
 
 #[test]
 fn just_enough() {
-    assert_eq!(transmute_bool_pedantic([0x00, 0x01].as_ref()), Ok([false, true].into_iter().as_slice()));
+    assert_eq!(transmute_bool_pedantic([0x00, 0x01].as_ref()), Ok(&[false, true][..]));
     assert_eq!(transmute_bool_pedantic([0x01, 0x01, 0x00, 0x01].as_ref()),
-               Ok([true, true, false, true].into_iter().as_slice()));
+               Ok(&[true, true, false, true][..]));
 }
 
 #[test]


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.