### PR TITLE
Fixed typo in lib docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //! feature through specifying `default-features = false` on import.
 //! However, `std` is only used for integration with `std::error::Error`.
 //!
-//! Note, though, that funxions operating on items from `alloc` will also be disabled by this.
+//! Note, though, that functions operating on items from `alloc` will also be disabled by this.
 //! If your no-`std` environment has an `alloc` implementation, you will have to reenable them by using `features = ["alloc"]`.
 //!
 //! # Migrating


### PR DESCRIPTION
It's just a super tiny typo that I stumbled upon while reading the docs.

Many thanks for all your work on this crate! ❤️ 