### PR TITLE
Use const-generics to implement `TriviallyTransmutable` for arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ exclude = ["*.enc"]
 default = ["std"]
 "std" = ["alloc"]
 "alloc" = []
+# Use const-generics for array trait implementations,
+# available in Rust 1.51 and above:
+# https://blog.rust-lang.org/2021/02/26/const-generics-mvp-beta.html
+const_generics = []

--- a/src/trivial.rs
+++ b/src/trivial.rs
@@ -14,15 +14,13 @@
 //! The effects of this range from less performance (e.g. x86) to trapping or
 //! address flooring (e.g. ARM), but this is undefined behavior nonetheless.
 
-
-use self::super::guard::{PermissiveGuard, PedanticGuard, Guard};
-use self::super::base::{transmute_many, transmute_many_mut, from_bytes};
 #[cfg(feature = "alloc")]
 use self::super::base::transmute_vec;
+use self::super::base::{from_bytes, transmute_many, transmute_many_mut};
+use self::super::guard::{Guard, PedanticGuard, PermissiveGuard};
 use self::super::Error;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-
 
 /// Type that can be constructed from any combination of bytes.
 ///
@@ -52,7 +50,6 @@ use alloc::vec::Vec;
 /// of the Nomicon for more details.
 pub unsafe trait TriviallyTransmutable: Copy {}
 
-
 unsafe impl TriviallyTransmutable for u8 {}
 unsafe impl TriviallyTransmutable for i8 {}
 unsafe impl TriviallyTransmutable for u16 {}
@@ -70,39 +67,45 @@ unsafe impl TriviallyTransmutable for u128 {}
 #[cfg(i128_type)]
 unsafe impl TriviallyTransmutable for i128 {}
 
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 1] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 2] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 3] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 4] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 5] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 6] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 7] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 8] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 9] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 10] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 11] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 12] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 13] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 14] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 15] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 16] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 17] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 18] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 19] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 20] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 21] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 22] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 23] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 24] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 25] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 26] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 27] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 28] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 29] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 30] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 31] {}
-unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 32] {}
+#[cfg(not(feature = "const_generics"))]
+mod trivially_transmutable_arrays {
+    use super::TriviallyTransmutable;
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 1] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 2] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 3] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 4] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 5] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 6] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 7] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 8] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 9] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 10] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 11] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 12] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 13] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 14] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 15] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 16] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 17] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 18] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 19] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 20] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 21] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 22] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 23] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 24] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 25] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 26] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 27] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 28] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 29] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 30] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 31] {}
+    unsafe impl<T: TriviallyTransmutable> TriviallyTransmutable for [T; 32] {}
+}
 
+#[cfg(feature = "const_generics")]
+unsafe impl<T: TriviallyTransmutable, const N: usize> TriviallyTransmutable for [T; N] {}
 
 /// Transmute the slice to a slice of another type, ensuring alignment of the types is maintained.
 ///
@@ -318,7 +321,6 @@ pub unsafe fn guarded_transmute_pod_many_permissive<T: TriviallyTransmutable>(by
 pub unsafe fn guarded_transmute_pod_many_pedantic<T: TriviallyTransmutable>(bytes: &[u8]) -> Result<&[T], Error<u8, T>> {
     transmute_many::<T, PedanticGuard>(bytes)
 }
-
 
 /// Transform a vector into a vector of another element type.
 ///


### PR DESCRIPTION
We'd like to use `safe-transmute` for arrays that are more than 32 elements in size, and [Const Generics](https://blog.rust-lang.org/2021/02/26/const-generics-mvp-beta.html) allow us to do that without implementing `TriviallyTransmutable` for the specific array sizes that are used.

Gated behind a `const_generics` feature because this is only available since 1.51, unless you feel like bumping MSRV for a new release?